### PR TITLE
chore: adapt AGENTS.md to ECC and resolve tooling conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,55 @@ jobs:
           set -euxo pipefail
           make -n ci || true
           make ci
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Cache backend venv
+        uses: actions/cache@v4
+        with:
+          path: api/.venv
+          key: venv-${{ runner.os }}-py312-${{ hashFiles('api/poetry.lock') }}
+
+      - name: Install backend dependencies
+        working-directory: api
+        run: poetry install --no-interaction
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.15.0 --activate
+
+      - name: Install frontend dependencies
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        working-directory: app
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E
+        run: make e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: app/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ coverage/
 htmlcov/
 *.log
 CLAUDE.md
+
+# Playwright E2E
+app/.e2e/
+api/.e2e/
+app/playwright-report/
+app/test-results/
+app/blob-report/
+app/playwright/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,176 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Philosophy and Methodology
+
+### Foundational Philosophy
+
+- Do the right thing because it’s the right thing
+- Leave it better than when you found it
+- Coding is an art form; go make art
+
+### Development Methodology
+
+- Measure twice and cut once — if you are unsure, confirm before proceeding
+- Smart code is better than clever code — prioritize clarity and maintainability
+- Start simple, add complexity only when needed
+- One change at a time — explain your reasoning
+
+### AI-Specific Constraints
+
+- When in doubt, ask — don’t assume
+- Respect existing patterns before suggesting new ones
+- Working software beats perfect documentation
+- Use the established tech stack unless there’s a compelling reason to change
+
+### Session Hygiene
+
+- Clean up after yourself — remove scripts and artifacts that are no longer necessary
+- Turn off the lights when leaving a room — close connections, shut down servers, leave the environment ready for the
+  next developer
+
+## Project Overview
+
+**My Private Finances** — a local-first, privacy-by-design personal finance app. No cloud, no telemetry, no external
+APIs. All data stays in a local SQLite database.
+
+Core flow: bank statement → CSV import → visualization → insights.
+
+## Repository Structure
+
+Monorepo with two main packages:
+
+- `api/` — Python backend (FastAPI + SQLModel + SQLite)
+- `app/` — React frontend (Vite + TypeScript + React Query)
+- `docs/adr/` — Architecture Decision Records
+
+## Commands
+
+All commands run from the repo root via Makefiles.
+
+### Full CI (runs both backend and frontend)
+
+```
+make ci
+```
+
+### Backend (api/)
+
+```
+make lint            # ruff check + format check
+make lint-fix        # ruff auto-fix + format (from api/ directory: make -C api lint-fix)
+make typecheck       # mypy
+make test            # pytest
+make test-cov        # pytest with coverage report
+make coverage        # pytest with 75% minimum coverage gate
+make migrate         # alembic upgrade head
+make check-migrations # detect schema drift via autogenerate
+```
+
+Run a single backend test:
+
+```
+cd api && poetry run pytest tests/path/to/test_file.py::test_name -v
+```
+
+### Frontend (app/)
+
+```
+make fe-lint         # eslint
+make fe-typecheck    # tsc
+make fe-format-check # prettier check
+make fe-test         # vitest
+```
+
+Run a single frontend test:
+
+```
+cd app && pnpm run test -- tests/path/to/test_file.test.ts
+```
+
+### Dev Servers
+
+```
+make -C api run      # uvicorn on port 5179
+make -C app run      # vite dev on port 5173 (proxies /api to backend)
+```
+
+### Dependency Installation
+
+```
+make sync            # install backend (poetry) + frontend (pnpm) deps
+```
+
+## Architecture
+
+### Backend (`api/my_private_finances/`)
+
+- `main.py` — FastAPI app factory
+- `db.py` — async SQLAlchemy engine + session creation
+- `deps.py` — FastAPI dependency injection (provides AsyncSession)
+- `models/` — SQLModel domain models (Account, Transaction, Category)
+- `schemas/` — Pydantic request/response schemas
+- `services/` — business logic (CSV import, transaction hashing)
+- `api/router.py` — aggregates all route modules
+- `api/routes/` — endpoint handlers
+- `cli/` — CLI tools (CSV import)
+
+Key conventions:
+
+- Async everywhere (AsyncSession, aiosqlite)
+- `Transaction(account_id, import_hash)` is UNIQUE for dedup
+- `import_hash` is SHA256, computed in `services/transaction_hash.py`
+- Tests use `SQLModel.metadata.create_all` (NOT Alembic) for schema setup
+- Decimal type for money amounts (never floats)
+
+### Frontend (`app/src/`)
+
+Layered architecture (enforced by ESLint `import/no-restricted-paths`):
+
+```
+pages/       → orchestration (can import from all layers below)
+components/  → reusable UI components
+hooks/       → React Query wrappers (useAccounts, useMonthlyReport)
+lib/api/     → fetch wrapper + API client functions (NO React imports)
+domain/      → DTO mappers + domain logic (pure functions)
+utils/       → pure helper functions (e.g., formatCurrency)
+```
+
+Dependency direction: pages → components/hooks → lib → domain → utils. Never import upward.
+
+Key conventions:
+
+- React Query (TanStack) for server state
+- CSS Modules for component styling
+- Recharts for data visualization
+- Zod for schema validation
+
+### Frontend-Backend Connection
+
+- Vite dev proxy: `/api` → `http://127.0.0.1:5179`
+- API base path: `/api/`
+
+## Database
+
+- SQLite at `data/my_private_finances.sqlite` (local, gitignored)
+- Migrations: Alembic (`api/alembic/versions/`)
+- CI uses separate DB at `api/.ci/my_private_finances.sqlite`
+- After model changes, create a migration: `cd api && poetry run alembic revision --autogenerate -m "description"`
+
+## Code Quality Tools
+
+| Tool     | Scope    | Purpose                     |
+|----------|----------|-----------------------------|
+| Ruff     | Backend  | Linting + formatting        |
+| MyPy     | Backend  | Type checking               |
+| ESLint   | Frontend | Linting + import rules      |
+| Prettier | Frontend | Formatting                  |
+| Vitest   | Frontend | Testing                     |
+| Pytest   | Backend  | Testing (asyncio_mode=auto) |
+
+## Package Managers
+
+- Backend: Poetry (`api/pyproject.toml`, venv at `api/.venv`)
+- Frontend: pnpm (`app/package.json`)
+- Node version: 20.x (`.nvmrc`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,176 +1,126 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Project-specific guidance for AI coding agents (Claude Code, Codex) working on
+**My Private Finances**.
 
-## Philosophy and Methodology
+Generic engineering practice — TDD, conventional commits, security checklists,
+code-quality review, agent orchestration — comes from ECC (Everything Claude
+Code) and its skills. This file only records what is specific to this repository.
+**When ECC guidance and this file disagree, this file wins.**
 
-### Foundational Philosophy
+> `AGENTS.md` is the single instruction file for this repo. `CLAUDE.md` is
+> intentionally git-ignored — do not create one; Claude Code reads `AGENTS.md`.
 
-- Do the right thing because it’s the right thing
-- Leave it better than when you found it
-- Coding is an art form; go make art
+## Non-negotiable constraints
 
-### Development Methodology
+- **Local-first, privacy by design.** No cloud, no telemetry, no analytics, no
+  third-party APIs, no outbound network requests at runtime. All data stays in a
+  local SQLite database.
+- A new runtime dependency that phones home, or any network call added to `api/`
+  or `app/` runtime code, is a design violation — stop and flag it.
+- Core flow: bank statement → CSV import → visualization → insights.
 
-- Measure twice and cut once — if you are unsure, confirm before proceeding
-- Smart code is better than clever code — prioritize clarity and maintainability
-- Start simple, add complexity only when needed
-- One change at a time — explain your reasoning
+## Layout
 
-### AI-Specific Constraints
+Monorepo:
 
-- When in doubt, ask — don’t assume
-- Respect existing patterns before suggesting new ones
-- Working software beats perfect documentation
-- Use the established tech stack unless there’s a compelling reason to change
-
-### Session Hygiene
-
-- Clean up after yourself — remove scripts and artifacts that are no longer necessary
-- Turn off the lights when leaving a room — close connections, shut down servers, leave the environment ready for the
-  next developer
-
-## Project Overview
-
-**My Private Finances** — a local-first, privacy-by-design personal finance app. No cloud, no telemetry, no external
-APIs. All data stays in a local SQLite database.
-
-Core flow: bank statement → CSV import → visualization → insights.
-
-## Repository Structure
-
-Monorepo with two main packages:
-
-- `api/` — Python backend (FastAPI + SQLModel + SQLite)
-- `app/` — React frontend (Vite + TypeScript + React Query)
-- `docs/adr/` — Architecture Decision Records
+- `api/` — Python backend (FastAPI + SQLModel + SQLite, fully async)
+- `app/` — React frontend (Vite + TypeScript + React 19 + TanStack Query)
+- `docs/adr/` — Architecture Decision Records (read before changing architecture)
+- `docs/product/` — vision, roadmap, and per-feature specs
 
 ## Commands
 
-All commands run from the repo root via Makefiles.
-
-### Full CI (runs both backend and frontend)
+All targets run from the repo root via Makefiles.
 
 ```
-make ci
+make ci               # full backend + frontend CI
+make sync             # install backend (poetry) + frontend (pnpm) deps
 ```
 
-### Backend (api/)
+Backend (`api/`):
 
 ```
-make lint            # ruff check + format check
-make lint-fix        # ruff auto-fix + format (from api/ directory: make -C api lint-fix)
-make typecheck       # mypy
-make test            # pytest
-make test-cov        # pytest with coverage report
-make coverage        # pytest with 75% minimum coverage gate
-make migrate         # alembic upgrade head
-make check-migrations # detect schema drift via autogenerate
+make lint             # ruff check + ruff format --check
+make lint-fix         # ruff --fix + ruff format
+make typecheck        # mypy
+make test             # pytest
+make test-cov         # pytest + coverage report (no gate)
+make coverage         # pytest, fails under MIN_COVERAGE (default 75)
+make migrate          # alembic upgrade head
+make check-migrations # fail if alembic autogenerate detects schema drift
+cd api && poetry run pytest tests/path/to/test_file.py::test_name -v   # single test
 ```
 
-Run a single backend test:
+Frontend (`app/`):
 
 ```
-cd api && poetry run pytest tests/path/to/test_file.py::test_name -v
+make fe-lint          # eslint
+make fe-typecheck     # tsc --noEmit
+make fe-format-check  # prettier --check
+make fe-test          # vitest run
+cd app && pnpm run test -- tests/path/to/file.test.ts                  # single test
 ```
 
-### Frontend (app/)
+Dev servers:
 
 ```
-make fe-lint         # eslint
-make fe-typecheck    # tsc
-make fe-format-check # prettier check
-make fe-test         # vitest
+make -C api run       # uvicorn on port 5179
+make -C app run       # vite dev on port 5173 (proxies /api → 127.0.0.1:5179)
 ```
 
-Run a single frontend test:
+## Backend conventions (`api/my_private_finances/`)
+
+Module map: `main.py` app factory · `db.py` async engine/session · `deps.py`
+DI (provides `AsyncSession`) · `models/` SQLModel domain models · `schemas/`
+Pydantic request/response · `services/` business logic · `api/router.py`
+aggregates `api/routes/` · `cli/` CSV import tools.
+
+- **Async everywhere** — `AsyncSession`, `aiosqlite`. Never call sync/blocking
+  I/O from a route.
+- **Money is `Decimal`, never `float`.**
+- `Transaction(account_id, import_hash)` is UNIQUE — this is the import dedup
+  key. `import_hash` is a SHA256 computed in `services/transaction_hash.py`.
+- Tests build the schema with `SQLModel.metadata.create_all`, **not** Alembic.
+- `Transaction.booking_date` must be a `date` object (not a string) when a row is
+  constructed directly in a test.
+- pytest runs with `asyncio_mode=auto`.
+
+## Database & migrations
+
+- SQLite at `data/my_private_finances.sqlite` (gitignored). CI uses a separate
+  DB at `api/.ci/my_private_finances.sqlite`.
+- Alembic migrations live in `api/alembic/versions/`; see `docs/migrations.md`.
+- After any model change: `cd api && poetry run alembic revision --autogenerate
+  -m "description"`, review the file, and commit it. `make check-migrations`
+  gates schema drift in CI.
+- Autogenerate emits `sqlmodel.sql.sqltypes.AutoString()` — replace it with
+  `sa.String()` in the migration (otherwise ruff F821).
+
+## Frontend conventions (`app/src/`)
+
+Layered architecture; dependency direction is enforced by ESLint
+`import/no-restricted-paths`:
 
 ```
-cd app && pnpm run test -- tests/path/to/test_file.test.ts
+pages/       → orchestration (may import from any layer below)
+components/  → reusable UI          hooks/ → TanStack Query wrappers
+lib/api/     → fetch wrapper + API client functions (no React imports)
+domain/      → DTO mappers + pure domain logic     utils/ → pure helpers
 ```
 
-### Dev Servers
+Never import upward. `lib/api.ts` is a barrel that re-exports the per-module
+clients; hooks import from `../lib/api/<module>` directly.
 
-```
-make -C api run      # uvicorn on port 5179
-make -C app run      # vite dev on port 5173 (proxies /api to backend)
-```
+- TanStack Query for server state · CSS Modules for styling · Recharts for
+  charts · Zod for schema validation · i18next for copy.
+- API base path is `/api/`.
 
-### Dependency Installation
+## Tooling — where ECC defaults do not apply
 
-```
-make sync            # install backend (poetry) + frontend (pnpm) deps
-```
-
-## Architecture
-
-### Backend (`api/my_private_finances/`)
-
-- `main.py` — FastAPI app factory
-- `db.py` — async SQLAlchemy engine + session creation
-- `deps.py` — FastAPI dependency injection (provides AsyncSession)
-- `models/` — SQLModel domain models (Account, Transaction, Category)
-- `schemas/` — Pydantic request/response schemas
-- `services/` — business logic (CSV import, transaction hashing)
-- `api/router.py` — aggregates all route modules
-- `api/routes/` — endpoint handlers
-- `cli/` — CLI tools (CSV import)
-
-Key conventions:
-
-- Async everywhere (AsyncSession, aiosqlite)
-- `Transaction(account_id, import_hash)` is UNIQUE for dedup
-- `import_hash` is SHA256, computed in `services/transaction_hash.py`
-- Tests use `SQLModel.metadata.create_all` (NOT Alembic) for schema setup
-- Decimal type for money amounts (never floats)
-
-### Frontend (`app/src/`)
-
-Layered architecture (enforced by ESLint `import/no-restricted-paths`):
-
-```
-pages/       → orchestration (can import from all layers below)
-components/  → reusable UI components
-hooks/       → React Query wrappers (useAccounts, useMonthlyReport)
-lib/api/     → fetch wrapper + API client functions (NO React imports)
-domain/      → DTO mappers + domain logic (pure functions)
-utils/       → pure helper functions (e.g., formatCurrency)
-```
-
-Dependency direction: pages → components/hooks → lib → domain → utils. Never import upward.
-
-Key conventions:
-
-- React Query (TanStack) for server state
-- CSS Modules for component styling
-- Recharts for data visualization
-- Zod for schema validation
-
-### Frontend-Backend Connection
-
-- Vite dev proxy: `/api` → `http://127.0.0.1:5179`
-- API base path: `/api/`
-
-## Database
-
-- SQLite at `data/my_private_finances.sqlite` (local, gitignored)
-- Migrations: Alembic (`api/alembic/versions/`)
-- CI uses separate DB at `api/.ci/my_private_finances.sqlite`
-- After model changes, create a migration: `cd api && poetry run alembic revision --autogenerate -m "description"`
-
-## Code Quality Tools
-
-| Tool     | Scope    | Purpose                     |
-|----------|----------|-----------------------------|
-| Ruff     | Backend  | Linting + formatting        |
-| MyPy     | Backend  | Type checking               |
-| ESLint   | Frontend | Linting + import rules      |
-| Prettier | Frontend | Formatting                  |
-| Vitest   | Frontend | Testing                     |
-| Pytest   | Backend  | Testing (asyncio_mode=auto) |
-
-## Package Managers
-
-- Backend: Poetry (`api/pyproject.toml`, venv at `api/.venv`)
-- Frontend: pnpm (`app/package.json`)
-- Node version: 20.x (`.nvmrc`)
+- **Ruff only** for Python lint + format. Do **not** add black, isort, or flake8.
+- Backend: Poetry (venv at `api/.venv`). Frontend: pnpm. Node **24** (`.nvmrc`).
+- Coverage gate is **75%** (`MIN_COVERAGE`), not ECC's 80%.
+- There is **no E2E / Playwright layer** — tests are pytest (backend) and vitest
+  (frontend) only.
+- Linter/formatter config files are fixed; fix the code, not the config.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,13 @@ make fe-test          # vitest run
 cd app && pnpm run test -- tests/path/to/file.test.ts                  # single test
 ```
 
+E2E (`app/e2e/`, Playwright — not part of `make ci`):
+
+```
+make e2e              # boots api + app, runs Playwright (Chromium)
+cd app && pnpm exec playwright install chromium                        # one-time
+```
+
 Dev servers:
 
 ```
@@ -126,6 +133,8 @@ clients; hooks import from `../lib/api/<module>` directly.
 - Backend coverage gate is **`MIN_COVERAGE` in `api/Makefile`** (currently 76%),
   ratcheting toward ECC's 80% target. Never lower it; raise it when coverage
   climbs. New code should land with tests.
-- There is **no E2E / Playwright layer** — tests are pytest (backend) and vitest
-  (frontend) only.
+- **Test layers:** pytest (backend unit + API via `AsyncClient`) and vitest
+  (frontend) run in `make ci`. Playwright E2E (`app/e2e/`) is a separate
+  `make e2e` / CI job — keep it out of `make ci`. Strategy + roadmap:
+  `docs/adr/0005-testing-strategy.md`.
 - Linter/formatter config files are fixed; fix the code, not the config.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,10 @@ clients; hooks import from `../lib/api/<module>` directly.
 
 ## Tooling — where ECC defaults do not apply
 
-- **Ruff only** for Python lint + format. Do **not** add black, isort, or flake8.
+- **Ruff is the sole Python linter and formatter** (config in `api/pyproject.toml`:
+  `line-length` 88, import sorting via lint rule `I`). Do not add black, isort, or
+  flake8. Third-party missing-stub handling goes in `[[tool.mypy.overrides]]`, not
+  inline `# type: ignore[import-untyped]`.
 - Backend: Poetry (venv at `api/.venv`). Frontend: pnpm. Node **24** (`.nvmrc`).
 - Coverage gate is **75%** (`MIN_COVERAGE`), not ECC's 80%.
 - There is **no E2E / Playwright layer** — tests are pytest (backend) and vitest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,9 @@ clients; hooks import from `../lib/api/<module>` directly.
   flake8. Third-party missing-stub handling goes in `[[tool.mypy.overrides]]`, not
   inline `# type: ignore[import-untyped]`.
 - Backend: Poetry (venv at `api/.venv`). Frontend: pnpm. Node **24** (`.nvmrc`).
-- Coverage gate is **75%** (`MIN_COVERAGE`), not ECC's 80%.
+- Backend coverage gate is **`MIN_COVERAGE` in `api/Makefile`** (currently 76%),
+  ratcheting toward ECC's 80% target. Never lower it; raise it when coverage
+  climbs. New code should land with tests.
 - There is **no E2E / Playwright layer** — tests are pytest (backend) and vitest
   (frontend) only.
 - Linter/formatter config files are fixed; fix the code, not the config.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,23 @@ pnpm rebuild
 
 ***
 
+### End-to-end tests (Playwright)
+
+E2E tests live in `app/e2e/` and boot the real backend + frontend. They are
+**not** part of `make ci` — run them separately:
+
+```bash
+cd app
+pnpm exec playwright install chromium   # one-time
+cd ..
+make e2e
+```
+
+Requires Poetry (backend) and pnpm (frontend) set up. See
+`docs/adr/0005-testing-strategy.md`.
+
+***
+
 ### Contributing Workflow
 1. Fork the repository 
 2. Create a feature branch from main (no direct commits to main)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help:
 	@echo "  make fe-format-check - Frontend prettier check"
 	@echo "  make fe-typecheck  - Frontend typecheck"
 	@echo "  make fe-test       - Frontend tests (if configured)"
+	@echo "  make e2e           - Playwright E2E smoke (boots api + app; not in ci)"
 	@echo "  make sync          - Install deps (backend + frontend)"
 
 .PHONY: ci
@@ -46,6 +47,10 @@ fe-typecheck:
 
 fe-test:
 	$(MAKE) -C app test
+
+.PHONY: e2e
+e2e:
+	$(MAKE) -C app e2e
 
 .PHONY: sync sync-backend sync-frontend
 sync: sync-backend sync-frontend

--- a/api/Makefile
+++ b/api/Makefile
@@ -42,8 +42,9 @@ test:
 test-cov:
 	poetry run pytest --cov=my_private_finances --cov-report=term-missing
 
-# CI/Gate: fail under MIN_COVERAGE
-MIN_COVERAGE ?= 75
+# CI/Gate: fail under MIN_COVERAGE.
+# Ratchet only upward toward the 80% target (ECC standard). Never lower it.
+MIN_COVERAGE ?= 76
 
 .PHONY: coverage
 coverage:

--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -4,13 +4,18 @@ import asyncio
 import os
 from logging.config import fileConfig
 
-from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 from sqlmodel import SQLModel
 
-from my_private_finances.models import Account, Budget, Category, Transaction  # noqa: F401
+from alembic import context
+from my_private_finances.models import (  # noqa: F401
+    Account,
+    Budget,
+    Category,
+    Transaction,
+)
 
 config = context.config
 if config.config_file_name is not None:

--- a/api/alembic/versions/246dcdcac806_add_csv_profile_table.py
+++ b/api/alembic/versions/246dcdcac806_add_csv_profile_table.py
@@ -8,9 +8,9 @@ Create Date: 2026-02-20 19:10:11.592253
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "246dcdcac806"

--- a/api/alembic/versions/2c39994ff739_add_row_filters_to_csv_profile.py
+++ b/api/alembic/versions/2c39994ff739_add_row_filters_to_csv_profile.py
@@ -8,9 +8,9 @@ Create Date: 2026-06-07 14:29:12.085616
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "2c39994ff739"

--- a/api/alembic/versions/520132a95287_add_recurring_pattern_table.py
+++ b/api/alembic/versions/520132a95287_add_recurring_pattern_table.py
@@ -8,9 +8,9 @@ Create Date: 2026-02-18 12:31:43.191095
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "520132a95287"

--- a/api/alembic/versions/752fd5b5bfb0_init_schema.py
+++ b/api/alembic/versions/752fd5b5bfb0_init_schema.py
@@ -8,9 +8,9 @@ Create Date: 2026-01-18 16:07:26.135668
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "752fd5b5bfb0"

--- a/api/alembic/versions/82014b421e83_add_watch_folder_config.py
+++ b/api/alembic/versions/82014b421e83_add_watch_folder_config.py
@@ -8,9 +8,9 @@ Create Date: 2026-03-04 20:51:15.196215
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "82014b421e83"

--- a/api/alembic/versions/8412074524e5_add_cost_type_to_category.py
+++ b/api/alembic/versions/8412074524e5_add_cost_type_to_category.py
@@ -8,9 +8,9 @@ Create Date: 2026-02-18 12:24:09.092039
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "8412074524e5"

--- a/api/alembic/versions/88fd2860bb1f_add_categorization_rule_table.py
+++ b/api/alembic/versions/88fd2860bb1f_add_categorization_rule_table.py
@@ -8,9 +8,9 @@ Create Date: 2026-02-16 19:30:19.437416
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "88fd2860bb1f"

--- a/api/alembic/versions/8cc9c1cc0191_add_opening_balance_to_account.py
+++ b/api/alembic/versions/8cc9c1cc0191_add_opening_balance_to_account.py
@@ -8,9 +8,9 @@ Create Date: 2026-02-18 22:44:00.257493
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "8cc9c1cc0191"

--- a/api/alembic/versions/c1022c065ce6_add_transfer_fields.py
+++ b/api/alembic/versions/c1022c065ce6_add_transfer_fields.py
@@ -8,9 +8,9 @@ Create Date: 2026-02-18 22:14:56.198888
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "c1022c065ce6"

--- a/api/alembic/versions/cb89e7b327d5_add_notes_to_transaction.py
+++ b/api/alembic/versions/cb89e7b327d5_add_notes_to_transaction.py
@@ -8,9 +8,9 @@ Create Date: 2026-06-03 17:42:26.327879
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "cb89e7b327d5"

--- a/api/alembic/versions/d282daea485b_add_budget_table.py
+++ b/api/alembic/versions/d282daea485b_add_budget_table.py
@@ -8,9 +8,9 @@ Create Date: 2026-02-17 19:50:04.487023
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d282daea485b"

--- a/api/my_private_finances/api/router.py
+++ b/api/my_private_finances/api/router.py
@@ -2,26 +2,26 @@ from fastapi import APIRouter
 
 from my_private_finances.api.routes import reports
 from my_private_finances.api.routes.accounts import router as accounts_router
+from my_private_finances.api.routes.annual import router as annual_router
 from my_private_finances.api.routes.budgets import router as budgets_router
 from my_private_finances.api.routes.categories import router as categories_router
 from my_private_finances.api.routes.categorization_rules import (
     router as categorization_rules_router,
 )
+from my_private_finances.api.routes.csv_profiles import router as csv_profiles_router
+from my_private_finances.api.routes.data_management import (
+    router as data_management_router,
+)
+from my_private_finances.api.routes.export import router as export_router
 from my_private_finances.api.routes.imports import router as imports_router
+from my_private_finances.api.routes.ml import router as ml_router
+from my_private_finances.api.routes.net_worth import router as net_worth_router
 from my_private_finances.api.routes.recurring_patterns import (
     router as recurring_patterns_router,
 )
 from my_private_finances.api.routes.transactions import router as transactions_router
 from my_private_finances.api.routes.transfers import router as transfers_router
-from my_private_finances.api.routes.net_worth import router as net_worth_router
 from my_private_finances.api.routes.trends import router as trends_router
-from my_private_finances.api.routes.annual import router as annual_router
-from my_private_finances.api.routes.csv_profiles import router as csv_profiles_router
-from my_private_finances.api.routes.export import router as export_router
-from my_private_finances.api.routes.data_management import (
-    router as data_management_router,
-)
-from my_private_finances.api.routes.ml import router as ml_router
 from my_private_finances.api.routes.watch_folder import router as watch_folder_router
 
 api_router = APIRouter()

--- a/api/my_private_finances/api/routes/imports.py
+++ b/api/my_private_finances/api/routes/imports.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, UploadFile
+
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import CsvProfile
 from my_private_finances.schemas import ImportResultResponse

--- a/api/my_private_finances/api/routes/recurring_patterns.py
+++ b/api/my_private_finances/api/routes/recurring_patterns.py
@@ -11,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Category, RecurringPattern
-from my_private_finances.utils.db_helpers import get_account_or_404
 from my_private_finances.schemas import (
     FrequencyTotal,
     RecurringPatternRead,
@@ -19,6 +18,7 @@ from my_private_finances.schemas import (
     RecurringSummary,
 )
 from my_private_finances.services.recurring_detection import run_detection
+from my_private_finances.utils.db_helpers import get_account_or_404
 
 router = APIRouter(prefix="/recurring-patterns", tags=["recurring-patterns"])
 

--- a/api/my_private_finances/api/routes/reports.py
+++ b/api/my_private_finances/api/routes/reports.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Optional, cast
 
 from fastapi import APIRouter, HTTPException
 from fastapi.params import Query
-from sqlalchemy import func, literal, select, case
+from sqlalchemy import case, func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from my_private_finances.deps import SessionDep

--- a/api/my_private_finances/api/routes/transactions.py
+++ b/api/my_private_finances/api/routes/transactions.py
@@ -1,22 +1,21 @@
 from datetime import date
 from decimal import Decimal
+from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, HTTPException
 from fastapi.params import Query
-from typing import Annotated, Any, Optional
 from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 
-from my_private_finances.models import Transaction, Category
+from my_private_finances.deps import SessionDep
+from my_private_finances.models import Category, Transaction
 from my_private_finances.schemas import (
-    TransactionRead,
     TransactionCreate,
     TransactionListResponse,
+    TransactionRead,
     TransactionUpdate,
 )
-
-from my_private_finances.deps import SessionDep
-from my_private_finances.services.transaction_hash import compute_import_hash, HashInput
+from my_private_finances.services.transaction_hash import HashInput, compute_import_hash
 from my_private_finances.utils.db_helpers import get_account_or_404
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])

--- a/api/my_private_finances/main.py
+++ b/api/my_private_finances/main.py
@@ -9,13 +9,13 @@ from typing import AsyncGenerator
 from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
+from my_private_finances.api.router import api_router
 from my_private_finances.config import get_data_dir
 from my_private_finances.db import (
     DEFAULT_DB_PATH,
     create_engine,
     create_session_factory,
 )
-from my_private_finances.api.router import api_router
 from my_private_finances.logging_config import setup_logging
 from my_private_finances.models.watch_folder_config import WatchSettings
 from my_private_finances.services.watch_folder import watch_folder_task

--- a/api/my_private_finances/schemas/__init__.py
+++ b/api/my_private_finances/schemas/__init__.py
@@ -1,4 +1,5 @@
 from .account import AccountCreate, AccountRead, AccountUpdate
+from .base import StrictSchema
 from .budget import BudgetCreate, BudgetRead, BudgetUpdate
 from .categorization_rule import (
     ApplyResult,
@@ -8,32 +9,31 @@ from .categorization_rule import (
     RuleUpdate,
 )
 from .category import CategoryCreate, CategoryRead, CategoryUpdate
-from .transaction_create import TransactionCreate
-from .transaction_read import TransactionRead
-from .transaction_update import TransactionUpdate
-from .transaction_list import TransactionListResponse
-from .base import StrictSchema
-from .recurring_pattern import (
-    FrequencyTotal,
-    RecurringPatternRead,
-    RecurringPatternUpdate,
-    RecurringSummary,
-)
-from .report_budget import BudgetComparison
-from .report_cost_type import CostTypeBreakdown, FixedVsVariableReport
-from .report_monthly import CategoryTotal, MonthlyReport, PayeeTotal, TopSpending
+from .csv_profile import CsvProfileCreate, CsvProfileRead, CsvProfileUpdate
 from .import_result import ImportResultResponse
-from .transfer import TransferCandidateRead, TransferLeg
+from .ml import Suggestion, TrainResult
 from .net_worth import (
     AccountBalancePoint,
     AccountNetWorthSummary,
     NetWorthPoint,
     NetWorthReport,
 )
+from .recurring_pattern import (
+    FrequencyTotal,
+    RecurringPatternRead,
+    RecurringPatternUpdate,
+    RecurringSummary,
+)
+from .report_annual import AnnualReport, MonthSummary
+from .report_budget import BudgetComparison
+from .report_cost_type import CostTypeBreakdown, FixedVsVariableReport
+from .report_monthly import CategoryTotal, MonthlyReport, PayeeTotal, TopSpending
 from .report_trend import CategoryTrendItem, SpendingTrendReport
-from .csv_profile import CsvProfileCreate, CsvProfileRead, CsvProfileUpdate
-from .report_annual import MonthSummary, AnnualReport
-from .ml import Suggestion, TrainResult
+from .transaction_create import TransactionCreate
+from .transaction_list import TransactionListResponse
+from .transaction_read import TransactionRead
+from .transaction_update import TransactionUpdate
+from .transfer import TransferCandidateRead, TransferLeg
 from .watch_folder import (
     WatchFolderConfigCreate,
     WatchFolderConfigRead,

--- a/api/my_private_finances/schemas/base.py
+++ b/api/my_private_finances/schemas/base.py
@@ -1,4 +1,4 @@
-from typing import cast, Any
+from typing import Any, cast
 
 from pydantic import ConfigDict
 from sqlmodel import SQLModel

--- a/api/my_private_finances/services/csv_import.py
+++ b/api/my_private_finances/services/csv_import.py
@@ -17,7 +17,7 @@ from my_private_finances.services.categorization import (
     load_rules_ordered,
     match_transaction,
 )
-from my_private_finances.services.transaction_hash import compute_import_hash, HashInput
+from my_private_finances.services.transaction_hash import HashInput, compute_import_hash
 
 logger = logging.getLogger(__name__)
 

--- a/api/my_private_finances/services/ml_categorization.py
+++ b/api/my_private_finances/services/ml_categorization.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import joblib  # type: ignore[import-untyped]
-from sklearn.calibration import CalibratedClassifierCV  # type: ignore[import-untyped]
-from sklearn.feature_extraction.text import TfidfVectorizer  # type: ignore[import-untyped]
-from sklearn.pipeline import Pipeline  # type: ignore[import-untyped]
-from sklearn.svm import LinearSVC  # type: ignore[import-untyped]
+import joblib
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.pipeline import Pipeline
+from sklearn.svm import LinearSVC
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 

--- a/api/my_private_finances/services/watch_folder.py
+++ b/api/my_private_finances/services/watch_folder.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from watchdog.events import FileCreatedEvent, FileSystemEventHandler  # type: ignore[import-untyped]
+from watchdog.events import (  # type: ignore[import-untyped]
+    FileCreatedEvent,
+    FileSystemEventHandler,
+)
 from watchdog.observers import Observer  # type: ignore[import-untyped]
 
 from my_private_finances.models import CsvProfile

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -42,6 +42,23 @@ dev = [
     "pytest-cov (>=7.0.0,<8.0.0)"
 ]
 
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+# Ruff is the sole Python linter and formatter for this project — no black,
+# isort, or flake8. Rule "I" provides import sorting (the isort replacement);
+# "E"/"F" (pycodestyle + pyflakes) are on by default.
+extend-select = ["I"]
+
+[[tool.mypy.overrides]]
+# scikit-learn and joblib ship no type information. Configured here rather than
+# with fragile per-import `# type: ignore` comments that Ruff's formatter can
+# detach from the line mypy reports.
+module = ["sklearn.*", "joblib.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import pytest_asyncio
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlmodel import SQLModel
 

--- a/api/tests/test_categorization_service.py
+++ b/api/tests/test_categorization_service.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 
-
 from my_private_finances.models import CategorizationRule, Transaction
 from my_private_finances.services.categorization import match_transaction
 

--- a/api/tests/test_recurring_detection.py
+++ b/api/tests/test_recurring_detection.py
@@ -14,7 +14,6 @@ from my_private_finances.services.recurring_detection import (
     run_detection,
 )
 
-
 # ── Pure heuristic tests (no DB) ──
 
 

--- a/api/tests/test_watch_folder.py
+++ b/api/tests/test_watch_folder.py
@@ -16,7 +16,6 @@ from my_private_finances.services.watch_folder import (
 )
 from tests.helpers import create_account
 
-
 # ---------------------------------------------------------------------------
 # Utility helpers
 # ---------------------------------------------------------------------------

--- a/app/.prettierignore
+++ b/app/.prettierignore
@@ -2,3 +2,9 @@ dist
 node_modules
 coverage
 pnpm-lock.yaml
+
+# Playwright artifacts
+.e2e
+playwright-report
+test-results
+blob-report

--- a/app/Makefile
+++ b/app/Makefile
@@ -7,6 +7,7 @@ help:
 	@echo "  make format-check - Prettier (check)"
 	@echo "  make typecheck  - TypeScript typecheck"
 	@echo "  make test       - Frontend tests (if configured)"
+	@echo "  make e2e        - Playwright E2E (boots api + app; not part of ci)"
 	@echo "  make sync       - Install dependencies"
 	@echo "  make run        - Run dev server"
 
@@ -34,6 +35,12 @@ test:
 .PHONY: ci
 ci: lint typecheck format-check test
 	@echo "✅ app checks passed"
+
+# E2E is deliberately not part of `ci` — it is heavier (boots the backend +
+# frontend, needs a browser) and runs as its own CI job. See docs/adr/0005.
+.PHONY: e2e
+e2e:
+	pnpm run e2e
 
 .PHONY: sync
 sync:

--- a/app/e2e/smoke.spec.ts
+++ b/app/e2e/smoke.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Smoke journey: seed an account through the API, then confirm the app shell
+ * renders, the frontend reaches the backend through the Vite proxy, and
+ * client-side navigation works. This is the seed of the E2E layer — grow it
+ * toward the real import -> visualize -> insights flow.
+ */
+test("app shell loads, talks to the API, and navigates", async ({ page, request }) => {
+  const seeded = await request.post("/api/accounts", {
+    data: { name: "E2E Checking", currency: "EUR" },
+  });
+  expect(seeded.ok()).toBeTruthy();
+
+  await page.goto("/");
+
+  // Shell + dashboard rendered from live API data.
+  await expect(page.getByRole("navigation")).toContainText("My Finances");
+  await expect(page.getByRole("heading", { name: "My Private Finances" })).toBeVisible();
+  await expect(page.getByText("Local-first dashboard.")).toBeVisible();
+  await expect(page.getByText(/Failed to load report/i)).toHaveCount(0);
+
+  // Client-side routing to the Import page.
+  await page.getByRole("link", { name: "Import" }).click();
+  await expect(page).toHaveURL(/\/import$/);
+  await expect(page.getByRole("button", { name: "Import CSV" })).toBeVisible();
+});

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run -c vitest.config.ts",
     "test:watch": "vitest -c vitest.config.ts",
+    "e2e": "playwright test",
+    "e2e:report": "playwright show-report",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
   },
@@ -26,6 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.63.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.0.1",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -4,7 +4,12 @@ import { defineConfig, devices } from "@playwright/test";
  * E2E config. Playwright boots the real stack: the FastAPI backend against a
  * throwaway SQLite DB (migrated fresh each run) and the Vite dev server, which
  * proxies `/api` to the backend. See docs/adr/0005-testing-strategy.md.
+ *
+ * Everything is pinned to the IPv4 loopback (127.0.0.1). Vite otherwise binds
+ * `localhost`, which resolves to ::1 first on CI runners and makes the 127.0.0.1
+ * baseURL unreachable.
  */
+const HOST = "127.0.0.1";
 const API_PORT = 5179;
 const WEB_PORT = 5173;
 const isCI = !!process.env.CI;
@@ -17,7 +22,7 @@ export default defineConfig({
   workers: isCI ? 1 : undefined,
   reporter: isCI ? [["github"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: `http://127.0.0.1:${WEB_PORT}`,
+    baseURL: `http://${HOST}:${WEB_PORT}`,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
@@ -27,11 +32,13 @@ export default defineConfig({
       command:
         "bash -c 'mkdir -p .e2e && rm -f .e2e/e2e.sqlite && " +
         "poetry run alembic upgrade head && " +
-        "exec poetry run uvicorn my_private_finances.main:app --port 5179 --log-level warning'",
+        `exec poetry run uvicorn my_private_finances.main:app --host ${HOST} --port ${API_PORT} --log-level warning'`,
       cwd: "../api",
-      port: API_PORT,
+      url: `http://${HOST}:${API_PORT}/api/accounts`,
       reuseExistingServer: !isCI,
       timeout: 120_000,
+      stdout: "pipe",
+      stderr: "pipe",
       env: {
         DATABASE_URL: "sqlite+aiosqlite:///./.e2e/e2e.sqlite",
         DATA_DIR: ".e2e",
@@ -39,10 +46,12 @@ export default defineConfig({
       },
     },
     {
-      command: `pnpm exec vite --port ${WEB_PORT} --strictPort`,
-      port: WEB_PORT,
+      command: `pnpm exec vite --host ${HOST} --port ${WEB_PORT} --strictPort`,
+      url: `http://${HOST}:${WEB_PORT}`,
       reuseExistingServer: !isCI,
       timeout: 60_000,
+      stdout: "pipe",
+      stderr: "pipe",
     },
   ],
 });

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * E2E config. Playwright boots the real stack: the FastAPI backend against a
+ * throwaway SQLite DB (migrated fresh each run) and the Vite dev server, which
+ * proxies `/api` to the backend. See docs/adr/0005-testing-strategy.md.
+ */
+const API_PORT = 5179;
+const WEB_PORT = 5173;
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: isCI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: `http://127.0.0.1:${WEB_PORT}`,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: [
+    {
+      command:
+        "bash -c 'mkdir -p .e2e && rm -f .e2e/e2e.sqlite && " +
+        "poetry run alembic upgrade head && " +
+        "exec poetry run uvicorn my_private_finances.main:app --port 5179 --log-level warning'",
+      cwd: "../api",
+      port: API_PORT,
+      reuseExistingServer: !isCI,
+      timeout: 120_000,
+      env: {
+        DATABASE_URL: "sqlite+aiosqlite:///./.e2e/e2e.sqlite",
+        DATA_DIR: ".e2e",
+        LOG_LEVEL: "WARNING",
+      },
+    },
+    {
+      command: `pnpm exec vite --port ${WEB_PORT} --strictPort`,
+      port: WEB_PORT,
+      reuseExistingServer: !isCI,
+      timeout: 60_000,
+    },
+  ],
+});

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      '@playwright/test':
+        specifier: ^1.63.0
+        version: 1.63.0
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -53,22 +56,22 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(supports-color@7.2.0)(vite@8.2.1(@types/node@26.0.1)(esbuild@0.27.2))
+        version: 5.2.0(vite@8.2.1(@types/node@26.0.1)(esbuild@0.27.2))
       eslint:
         specifier: ^9.39.1
-        version: 9.39.2(supports-color@7.2.0)
+        version: 9.39.2
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.2(supports-color@7.2.0))
+        version: 10.1.8(eslint@9.39.2)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 7.1.1(eslint@9.39.2)
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
-        version: 0.5.2(eslint@9.39.2(supports-color@7.2.0))
+        version: 0.5.2(eslint@9.39.2)
       globals:
         specifier: ^17.11.0
         version: 17.11.0
@@ -83,7 +86,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.60.1
-        version: 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 8.60.1(eslint@9.39.2)(typescript@5.9.3)
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.0.1)(esbuild@0.27.2)
@@ -496,6 +499,11 @@ packages:
   '@oxc-project/types@0.144.0':
     resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
+  '@playwright/test@1.63.0':
+    resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
     peerDependencies:
@@ -542,42 +550,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.4':
     resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.4':
     resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.4':
     resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.4':
     resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.4':
     resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
@@ -1606,28 +1608,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -1773,6 +1771,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2321,20 +2329,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@7.2.0)':
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2359,19 +2367,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -2396,14 +2404,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.28.6': {}
@@ -2418,7 +2426,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
 
-  '@babel/traverse@7.29.8(supports-color@7.2.0)':
+  '@babel/traverse@7.29.8':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
@@ -2426,7 +2434,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2546,22 +2554,22 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2)':
     dependencies:
-      eslint: 9.39.2(supports-color@7.2.0)
+      eslint: 9.39.2
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2)':
     dependencies:
-      eslint: 9.39.2(supports-color@7.2.0)
+      eslint: 9.39.2
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1(supports-color@7.2.0)':
+  '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2574,10 +2582,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.3(supports-color@7.2.0)':
+  '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -2632,6 +2640,10 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@oxc-project/types@0.144.0': {}
+
+  '@playwright/test@1.63.0':
+    dependencies:
+      playwright: 1.63.0
 
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
     dependencies:
@@ -2810,15 +2822,15 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@9.39.2)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.60.1
-      '@typescript-eslint/type-utils': 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.60.1(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@9.39.2)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.60.1
-      eslint: 9.39.2(supports-color@7.2.0)
+      eslint: 9.39.2
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -2826,23 +2838,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.60.1(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.60.1
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 9.39.2(supports-color@7.2.0)
+      debug: 4.4.3
+      eslint: 9.39.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.60.1(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.60.1(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.60.1
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2856,13 +2868,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.60.1(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 9.39.2(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@9.39.2)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.2
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2870,13 +2882,13 @@ snapshots:
 
   '@typescript-eslint/types@8.60.1': {}
 
-  '@typescript-eslint/typescript-estree@8.60.1(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.60.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.60.1(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.60.1(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/visitor-keys': 8.60.1
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.1
       tinyglobby: 0.2.17
@@ -2885,13 +2897,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.60.1(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 9.39.2(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@5.9.3)
+      eslint: 9.39.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2901,11 +2913,11 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@5.2.0(supports-color@7.2.0)(vite@8.2.1(@types/node@26.0.1)(esbuild@0.27.2))':
+  '@vitejs/plugin-react@5.2.0(vite@8.2.1(@types/node@26.0.1)(esbuild@0.27.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -3188,17 +3200,13 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  debug@3.2.7(supports-color@7.2.0):
+  debug@3.2.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   decimal.js-light@2.5.1: {}
 
@@ -3360,40 +3368,40 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.2(supports-color@7.2.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.2):
     dependencies:
-      eslint: 9.39.2(supports-color@7.2.0)
+      eslint: 9.39.2
 
-  eslint-import-resolver-node@0.3.9(supports-color@7.2.0):
+  eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@7.2.0)
+      debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9(supports-color@7.2.0))(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2):
     dependencies:
-      debug: 3.2.7(supports-color@7.2.0)
+      debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 9.39.2(supports-color@7.2.0)
-      eslint-import-resolver-node: 0.3.9(supports-color@7.2.0)
+      '@typescript-eslint/parser': 8.60.1(eslint@9.39.2)(typescript@5.9.3)
+      eslint: 9.39.2
+      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7(supports-color@7.2.0)
+      debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(supports-color@7.2.0)
-      eslint-import-resolver-node: 0.3.9(supports-color@7.2.0)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9(supports-color@7.2.0))(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint: 9.39.2
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3405,26 +3413,26 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@9.39.2)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-react-hooks@7.1.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.2):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
-      eslint: 9.39.2(supports-color@7.2.0)
+      eslint: 9.39.2
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.2(eslint@9.39.2(supports-color@7.2.0)):
+  eslint-plugin-react-refresh@0.5.2(eslint@9.39.2):
     dependencies:
-      eslint: 9.39.2(supports-color@7.2.0)
+      eslint: 9.39.2
 
   eslint-scope@8.4.0:
     dependencies:
@@ -3437,14 +3445,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.2(supports-color@7.2.0):
+  eslint@9.39.2:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1(supports-color@7.2.0)
+      '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.3(supports-color@7.2.0)
+      '@eslint/eslintrc': 3.3.3
       '@eslint/js': 9.39.2
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -3454,7 +3462,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -3994,6 +4002,12 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  playwright-core@1.63.0: {}
+
+  playwright@1.63.0:
+    dependencies:
+      playwright-core: 1.63.0
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.26:
@@ -4358,13 +4372,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  typescript-eslint@8.60.1(eslint@9.39.2)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.60.1(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@9.39.2(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 9.39.2(supports-color@7.2.0)
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@9.39.2)(typescript@5.9.3)
+      eslint: 9.39.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/app/tsconfig.node.json
+++ b/app/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts", "e2e"]
 }

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -7,5 +7,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./tests/setup.ts"],
+    // Unit/component tests only. Playwright specs in e2e/ are run by `make e2e`.
+    include: ["tests/**/*.{test,spec}.{ts,tsx}"],
   },
 });

--- a/docs/adr/0005-testing-strategy.md
+++ b/docs/adr/0005-testing-strategy.md
@@ -1,0 +1,78 @@
+# ADR 0005: Testing Strategy
+
+Date: 2026-09-08
+Status: Accepted
+
+***
+
+## Context
+
+The project uses [ECC (Everything Claude Code)](https://github.com/affaan-m/ECC)
+for AI-assisted development. ECC's baseline testing rule requires three test
+layers — unit, integration, and end-to-end — with browser E2E treated as
+mandatory.
+
+Until now this repo had two layers:
+
+- **Backend:** pytest, including HTTP-level API tests via `httpx.AsyncClient` +
+  `ASGITransport` (integration coverage without a running server).
+- **Frontend:** Vitest + Testing Library (component and hook behaviour, jsdom).
+
+There was no test that exercised the real frontend against the real backend, so
+regressions in the wiring between them — the Vite proxy, API base paths,
+serialization, routing — could only be caught by hand.
+
+## Decision
+
+Adopt a **browser E2E layer using Playwright**, owned by the frontend package.
+
+### Scope and layering
+
+| Layer | Tool | Location | Runs in |
+|---|---|---|---|
+| Backend unit + API | pytest (`AsyncClient`) | `api/tests/` | `make ci` |
+| Frontend unit/component | Vitest + Testing Library | `app/tests/` | `make ci` |
+| End-to-end | Playwright (Chromium) | `app/e2e/` | `make e2e` — separate CI job |
+
+E2E is **not** part of `make ci`. It is heavier (boots the backend and frontend,
+needs a browser binary) and runs as its own GitHub Actions job so it does not
+slow the inner loop or the main CI gate.
+
+### How it runs
+
+`playwright.config.ts` starts the full stack via `webServer`:
+
+- the FastAPI backend on port 5179 against a throwaway SQLite DB
+  (`api/.e2e/e2e.sqlite`, gitignored), migrated with `alembic upgrade head` on
+  every run;
+- the Vite dev server on port 5173, which proxies `/api` to the backend.
+
+Tests seed their own state through the API and assert against the rendered UI.
+
+### Current coverage
+
+One smoke journey (`app/e2e/smoke.spec.ts`): seed an account, confirm the app
+shell renders from live API data, confirm client-side routing works. This is a
+deliberate seed, not the finished layer.
+
+### Where it grows
+
+Priority journeys to add next, in order:
+
+1. CSV import → transactions appear in the list
+2. Import → categorization rule applied → dashboard reflects it
+3. Multi-account net-worth view
+
+When the desktop app (product feature 110, Tauri) lands, revisit whether E2E
+should also drive the packaged desktop shell rather than only the browser.
+
+## Consequences
+
+- CI gains a second required job (`e2e`). Total CI time increases; the fast
+  `ci` job is unchanged.
+- `@playwright/test` is a frontend dev dependency; contributors run
+  `pnpm exec playwright install chromium` once. Documented in CONTRIBUTING.md.
+- The privacy/local-first posture is unaffected — the E2E stack is entirely
+  local, no external services.
+- ECC's "E2E required" expectation is now met with a real, if small, layer
+  instead of a documented exception.


### PR DESCRIPTION
## What

Adapts `AGENTS.md` to work cleanly with ECC (Everything Claude Code) and resolves
the three places where this repo diverged from ECC's defaults.

## Commits (reviewable individually)

1. **`docs: add AGENTS.md (pre-ECC baseline)`** — commits the previously-untracked
   `AGENTS.md` as-is, so the diff of the rewrite is visible.
2. **`docs: adapt AGENTS.md to ECC conventions`** — rewrite as a lean,
   project-specific file: drop generic guidance now covered by ECC skills/rules
   (philosophy, KISS/DRY/YAGNI, commit style); keep and sharpen project specifics
   (local-first/privacy constraints, Make commands, backend invariants, frontend
   layering, migrations); retitle from `CLAUDE.md`; fix stale facts (Node 20→24,
   React 19).
3. **`chore(api): make Ruff the explicit, sole Python lint+format tool`**
   — Conflict 1. ECC's Python rule prescribes black + isort; Ruff already covers
   both. Add explicit `[tool.ruff]` / `[tool.ruff.lint]` config (rule `I` for
   import sorting), apply the one-time import reordering, move scikit-learn/joblib
   stub handling into `[[tool.mypy.overrides]]`.
4. **`chore(api): ratchet coverage gate 75->76%, target 80%`** — Conflict 2.
   ECC mandates 80%; current backend coverage is 76.25%. Lock that in as a
   no-regression floor and document 80% as the ratchet target.
5. **`test(e2e): scaffold Playwright E2E layer`** — Conflict 3. ECC treats
   browser E2E as required; this repo had none. Adds `app/e2e/` with a smoke
   journey, `playwright.config.ts` that boots the full stack, `make e2e`, a
   dedicated CI job, and ADR 0005. **Kept out of `make ci`** (heavier, needs a
   browser).
6. **`fix(e2e): pin dev servers to IPv4 loopback for CI`** — the first CI run of
   the e2e job caught that Vite binds `localhost`/`::1` on runners; pin uvicorn
   and vite to `--host 127.0.0.1` and use HTTP `url` readiness probes.

## Test plan

- [x] `make ci` green (backend: ruff + mypy + pytest @ 76.25% + migration drift; frontend: eslint + tsc + prettier + vitest)
- [x] `make e2e` green (Playwright smoke, Chromium)
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] CI `ci` + `e2e` jobs green on GitHub

## Notes

- Requires Node 24 locally (`.nvmrc`; jsdom 30). Verified under `nvm use 24`.
- Pre-existing (not touched here): `tsc -b` reports 3 type errors in `app/tests/`
  that `make ci`'s `tsc -p` does not catch. Worth a follow-up.
- No application code behavior changes; the backend diff is import ordering only.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm

