### PR TITLE
fix(api): enforce SQLite foreign keys at runtime (#96)

### DIFF
--- a/api/my_private_finances/api/routes/categories.py
+++ b/api/my_private_finances/api/routes/categories.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Body, HTTPException
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
 from my_private_finances.deps import SessionDep
@@ -93,4 +94,17 @@ async def delete_category(category_id: int, session: SessionDep):
         )
 
     await session.delete(db_obj)
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError as e:
+        # Foreign keys are enforced (PRAGMA foreign_keys=ON): the category is
+        # still referenced by a budget, categorization rule, sub-category, or
+        # recurring pattern.
+        await session.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Category is still referenced (budget, rule, sub-category, or "
+                "recurring pattern) and cannot be deleted"
+            ),
+        ) from e

--- a/api/my_private_finances/api/routes/csv_profiles.py
+++ b/api/my_private_finances/api/routes/csv_profiles.py
@@ -115,5 +115,12 @@ async def delete_csv_profile(profile_id: int, session: SessionDep) -> None:
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Profile not found")
     await session.delete(db_obj)
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError as e:
+        await session.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Profile is in use by a watch-folder config and cannot be deleted",
+        ) from e
     logger.info("CSV profile deleted: id=%d", profile_id)

--- a/api/my_private_finances/api/routes/transactions.py
+++ b/api/my_private_finances/api/routes/transactions.py
@@ -29,6 +29,10 @@ async def create_transaction(
 ) -> TransactionRead:
     await get_account_or_404(session, tx.account_id)
 
+    if tx.category_id is not None:
+        if await session.get(Category, tx.category_id) is None:
+            raise HTTPException(status_code=422, detail="Category not found")
+
     import_hash = compute_import_hash(
         HashInput(
             account_id=tx.account_id,

--- a/api/my_private_finances/db.py
+++ b/api/my_private_finances/db.py
@@ -4,6 +4,7 @@ import os
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -34,10 +35,25 @@ def ensure_sqlite_dir(database_url: str) -> None:
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
 
+def _enable_sqlite_foreign_keys(engine: AsyncEngine) -> None:
+    """SQLite does not enforce foreign keys unless `PRAGMA foreign_keys=ON` is
+    issued per connection. Attach it to the underlying sync engine's connect
+    event so every pooled connection (including aiosqlite's) has it set."""
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_pragma(dbapi_connection: object, _connection_record: object) -> None:
+        cursor = dbapi_connection.cursor()  # type: ignore[attr-defined]
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
 def create_engine(database_url: str | None = None) -> AsyncEngine:
     url = database_url or get_database_url()
     ensure_sqlite_dir(url)
-    return create_async_engine(url, echo=False, future=True)
+    engine = create_async_engine(url, echo=False, future=True)
+    if url.startswith("sqlite"):
+        _enable_sqlite_foreign_keys(engine)
+    return engine
 
 
 def create_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:

--- a/api/tests/test_foreign_keys.py
+++ b/api/tests/test_foreign_keys.py
@@ -1,0 +1,73 @@
+"""SQLite foreign-key enforcement (issue #96).
+
+`PRAGMA foreign_keys=ON` is attached per connection in `db.create_engine`, so
+referential integrity is enforced at runtime and the API turns the resulting
+`IntegrityError` into a 409/422 instead of a silent orphan row or a 500.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers import create_account, create_budget, create_category
+
+
+@pytest.mark.asyncio
+async def test_pragma_foreign_keys_is_enabled(db_session: AsyncSession) -> None:
+    result = await db_session.execute(text("PRAGMA foreign_keys"))
+    assert result.scalar_one() == 1
+
+
+@pytest.mark.asyncio
+async def test_create_transaction_with_unknown_category_returns_422(
+    test_app: AsyncClient,
+) -> None:
+    account = await create_account(test_app)
+    res = await test_app.post(
+        "/api/transactions",
+        json={
+            "account_id": account["id"],
+            "booking_date": "2026-02-01",
+            "amount": "10.00",
+            "currency": "EUR",
+            "payee": "X",
+            "purpose": "Y",
+            "import_source": "manual",
+            "external_id": "fk-1",
+            "category_id": 999999,
+        },
+    )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_delete_category_referenced_by_budget_returns_409(
+    test_app: AsyncClient,
+) -> None:
+    cat = await create_category(test_app, name="Rent")
+    await create_budget(test_app, category_id=cat["id"], amount="900.00")
+
+    res = await test_app.delete(f"/api/categories/{cat['id']}")
+    assert res.status_code == 409
+
+    # The category and its budget are both still there.
+    assert len((await test_app.get("/api/categories")).json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_csv_profile_in_use_returns_409(test_app: AsyncClient) -> None:
+    account = await create_account(test_app)
+    profile = (await test_app.post("/api/csv-profiles", json={"name": "Bank X"})).json()
+    cfg = await test_app.post(
+        "/api/watch-folder/configs",
+        json={
+            "subfolder_name": "bank-x",
+            "account_id": account["id"],
+            "profile_id": profile["id"],
+        },
+    )
+    assert cfg.status_code == 201, cfg.text
+
+    res = await test_app.delete(f"/api/csv-profiles/{profile['id']}")
+    assert res.status_code == 409

--- a/api/tests/test_ml_service.py
+++ b/api/tests/test_ml_service.py
@@ -8,12 +8,21 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from my_private_finances.models import Category, Transaction
+from my_private_finances.models import Account, Category, Transaction
 from my_private_finances.services.ml_categorization import (
     ColdStartError,
     suggest,
     train,
 )
+
+
+async def _seed_account(db_session: AsyncSession) -> int:
+    account = Account(name="Main", currency="EUR")
+    db_session.add(account)
+    await db_session.commit()
+    await db_session.refresh(account)
+    assert account.id is not None
+    return account.id
 
 
 def _make_tx(
@@ -40,13 +49,14 @@ async def test_train_insufficient_data_raises_cold_start(
     db_session: AsyncSession,
 ) -> None:
     # Add fewer than 10 categorized transactions
+    account_id = await _seed_account(db_session)
     cat = Category(name="Groceries")
     db_session.add(cat)
     await db_session.commit()
     await db_session.refresh(cat)
 
     for i in range(5):
-        db_session.add(_make_tx(1, f"hash-{i}", category_id=cat.id))
+        db_session.add(_make_tx(account_id, f"hash-{i}", category_id=cat.id))
     await db_session.commit()
 
     with pytest.raises(ColdStartError):
@@ -55,6 +65,7 @@ async def test_train_insufficient_data_raises_cold_start(
 
 @pytest.mark.asyncio
 async def test_train_returns_stats(db_session: AsyncSession, tmp_path: Path) -> None:
+    account_id = await _seed_account(db_session)
     cat1 = Category(name="Groceries")
     cat2 = Category(name="Transport")
     db_session.add(cat1)
@@ -64,11 +75,13 @@ async def test_train_returns_stats(db_session: AsyncSession, tmp_path: Path) -> 
     await db_session.refresh(cat2)
 
     for i in range(6):
-        db_session.add(_make_tx(1, f"hash-g{i}", category_id=cat1.id, payee="REWE"))
+        db_session.add(
+            _make_tx(account_id, f"hash-g{i}", category_id=cat1.id, payee="REWE")
+        )
     for i in range(6):
         db_session.add(
             _make_tx(
-                1,
+                account_id,
                 f"hash-t{i}",
                 category_id=cat2.id,
                 payee="BVG",
@@ -93,6 +106,7 @@ async def test_train_returns_stats(db_session: AsyncSession, tmp_path: Path) -> 
 async def test_suggest_returns_predictions(
     db_session: AsyncSession, tmp_path: Path
 ) -> None:
+    account_id = await _seed_account(db_session)
     cat1 = Category(name="Groceries")
     cat2 = Category(name="Transport")
     db_session.add(cat1)
@@ -102,11 +116,13 @@ async def test_suggest_returns_predictions(
     await db_session.refresh(cat2)
 
     for i in range(6):
-        db_session.add(_make_tx(1, f"hash-g{i}", category_id=cat1.id, payee="REWE"))
+        db_session.add(
+            _make_tx(account_id, f"hash-g{i}", category_id=cat1.id, payee="REWE")
+        )
     for i in range(6):
         db_session.add(
             _make_tx(
-                1,
+                account_id,
                 f"hash-t{i}",
                 category_id=cat2.id,
                 payee="BVG",
@@ -114,7 +130,9 @@ async def test_suggest_returns_predictions(
             )
         )
     # Add uncategorized transaction
-    db_session.add(_make_tx(1, "hash-uncat", category_id=None, payee="REWE Markt"))
+    db_session.add(
+        _make_tx(account_id, "hash-uncat", category_id=None, payee="REWE Markt")
+    )
     await db_session.commit()
 
     model_path = tmp_path / "ml_model.joblib"


### PR DESCRIPTION
Closes #96 (runtime-enforcement scope; cascade semantics tracked in the follow-up issue).

## Problem
SQLite ignores foreign keys unless `PRAGMA foreign_keys=ON` is set per connection. Every `foreign_key=` in the models was unenforced — orphan rows and dangling references were silently accepted (review finding SEC1).

## Change
- `db.create_engine`: connect-event listener issuing `PRAGMA foreign_keys=ON` on every sqlite connection.
- `delete_category` / `delete_csv_profile`: catch the now-raised `IntegrityError` -> **409**.
- `create_transaction`: unknown `category_id` -> **422** (parity with `update_transaction`).
- New `tests/test_foreign_keys.py`; fixed `test_ml_service` (was relying on an orphan `account_id`).

Deferred (new issue): explicit `ondelete`/CASCADE semantics + the SQLite batch migration.

## Test plan
- [x] `make ci` green (lint, mypy, 249 tests, coverage 75.97%, no migration drift)
- [ ] CI green on GitHub

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm