### PR TITLE
fix(api): export/restore target the engine's DB file; validate restores (#97)

### DIFF
--- a/api/my_private_finances/api/routes/data_management.py
+++ b/api/my_private_finances/api/routes/data_management.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request, UploadFile
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy import delete, func, select
 
 from my_private_finances.db import sqlite_path_from_engine
@@ -87,6 +88,16 @@ def _validate_restore_candidate(path: str) -> None:
         conn.close()
 
 
+def _sqlite_copy(src_path: str, dst_path: str) -> None:
+    src = sqlite3.connect(src_path)
+    dst = sqlite3.connect(dst_path)
+    try:
+        src.backup(dst)
+    finally:
+        dst.close()
+        src.close()
+
+
 @router.post("/restore/sqlite", status_code=200)
 async def restore_sqlite(file: UploadFile, request: Request) -> dict:
     data = await file.read()
@@ -112,13 +123,7 @@ async def restore_sqlite(file: UploadFile, request: Request) -> dict:
             # Release all pooled async connections before writing
             await request.app.state.engine.dispose()
 
-            src = sqlite3.connect(tmp_path)
-            dst = sqlite3.connect(dst_path)
-            try:
-                src.backup(dst)
-            finally:
-                dst.close()
-                src.close()
+            await run_in_threadpool(_sqlite_copy, tmp_path, dst_path)
         finally:
             if tmp_path is not None:
                 os.unlink(tmp_path)

--- a/api/my_private_finances/api/routes/data_management.py
+++ b/api/my_private_finances/api/routes/data_management.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sqlite3
 import tempfile
+from functools import lru_cache
+from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request, UploadFile
 from sqlalchemy import delete, func, select
 
+from my_private_finances.db import sqlite_path_from_engine
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import (
     Account,
@@ -26,6 +30,61 @@ logger = logging.getLogger(__name__)
 
 _SQLITE_MAGIC = b"SQLite format 3\x00"
 _MAX_RESTORE_BYTES = 500 * 1024 * 1024  # 500 MB
+_VERSIONS_DIR = Path(__file__).resolve().parents[3] / "alembic" / "versions"
+
+
+@lru_cache(maxsize=1)
+def _known_alembic_revisions() -> frozenset[str]:
+    """Revision ids of migrations shipped with this build."""
+    revisions: set[str] = set()
+    for path in _VERSIONS_DIR.glob("*.py"):
+        match = re.search(
+            r"""^revision(?::\s*str)?\s*=\s*["']([^"']+)["']""",
+            path.read_text(),
+            re.MULTILINE,
+        )
+        if match:
+            revisions.add(match.group(1))
+    return frozenset(revisions)
+
+
+_CORE_TABLES = {"account", "transaction", "category"}
+
+
+def _validate_restore_candidate(path: str) -> None:
+    """Raise HTTPException unless *path* is an intact My Private Finances DB."""
+    conn = sqlite3.connect(path)
+    try:
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()
+        if not integrity or integrity[0] != "ok":
+            raise HTTPException(status_code=400, detail="SQLite integrity check failed")
+
+        tables = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        if not _CORE_TABLES <= tables:
+            raise HTTPException(
+                status_code=400, detail="Not a recognised My Private Finances backup"
+            )
+
+        if "alembic_version" in tables:
+            row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+            known = _known_alembic_revisions()
+            if row is not None and known and row[0] not in known:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Backup schema revision is not recognised by this "
+                        "version — restore it into a matching build, then upgrade."
+                    ),
+                )
+    except sqlite3.DatabaseError as e:
+        raise HTTPException(
+            status_code=400, detail="Not a recognised My Private Finances backup"
+        ) from e
+    finally:
+        conn.close()
 
 
 @router.post("/restore/sqlite", status_code=200)
@@ -36,23 +95,33 @@ async def restore_sqlite(file: UploadFile, request: Request) -> dict:
     if data[:16] != _SQLITE_MAGIC:
         raise HTTPException(status_code=400, detail="Not a valid SQLite file")
 
+    lock = request.app.state.restore_lock
+    if lock.locked():
+        raise HTTPException(status_code=409, detail="A restore is already in progress")
+
     tmp_path: str | None = None
-    try:
-        with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as tmp:
-            tmp.write(data)
-            tmp_path = tmp.name
+    async with lock:
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as tmp:
+                tmp.write(data)
+                tmp_path = tmp.name
 
-        # Release all pooled async connections before writing
-        await request.app.state.engine.dispose()
+            _validate_restore_candidate(tmp_path)
 
-        src = sqlite3.connect(tmp_path)
-        dst = sqlite3.connect(str(request.app.state.db_path))
-        src.backup(dst)
-        dst.close()
-        src.close()
-    finally:
-        if tmp_path is not None:
-            os.unlink(tmp_path)
+            dst_path = str(sqlite_path_from_engine(request.app.state.engine))
+            # Release all pooled async connections before writing
+            await request.app.state.engine.dispose()
+
+            src = sqlite3.connect(tmp_path)
+            dst = sqlite3.connect(dst_path)
+            try:
+                src.backup(dst)
+            finally:
+                dst.close()
+                src.close()
+        finally:
+            if tmp_path is not None:
+                os.unlink(tmp_path)
 
     logger.info("Database restored from uploaded SQLite backup")
     return {"ok": True}

--- a/api/my_private_finances/api/routes/export.py
+++ b/api/my_private_finances/api/routes/export.py
@@ -14,6 +14,7 @@ from fastapi.responses import FileResponse, Response
 from sqlmodel import select
 from starlette.background import BackgroundTask
 
+from my_private_finances.db import sqlite_path_from_engine
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import (
     Account,
@@ -41,7 +42,7 @@ def _serialize(obj: Any) -> Any:
 
 @router.get("/sqlite")
 async def export_sqlite(request: Request) -> FileResponse:
-    db_path = request.app.state.db_path
+    db_path = sqlite_path_from_engine(request.app.state.engine)
     tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
     tmp.close()
 

--- a/api/my_private_finances/db.py
+++ b/api/my_private_finances/db.py
@@ -44,6 +44,21 @@ def create_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSessi
     return async_sessionmaker(engine, expire_on_commit=False)
 
 
+def sqlite_path_from_engine(engine: AsyncEngine) -> Path:
+    """The on-disk SQLite file backing *engine*.
+
+    Use this instead of a separately-tracked path: export/restore must operate
+    on the file the engine is actually connected to, which is derived from
+    ``DATABASE_URL`` and may differ from ``DEFAULT_DB_PATH``.
+    """
+    url = engine.url
+    if not url.drivername.startswith("sqlite"):
+        raise ValueError(f"Not a SQLite engine: {url.drivername}")
+    if not url.database or url.database == ":memory:":
+        raise ValueError("SQLite engine is not backed by a file")
+    return Path(url.database)
+
+
 async def get_session(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[AsyncSession, None]:

--- a/api/my_private_finances/main.py
+++ b/api/my_private_finances/main.py
@@ -67,6 +67,7 @@ def create_app(db_path: Path = DEFAULT_DB_PATH) -> FastAPI:
     app.state.engine = engine
     app.state.session_factory = session_factory
     app.state.db_path = db_path
+    app.state.restore_lock = asyncio.Lock()
     app.include_router(api_router, prefix="/api")
 
     return app

--- a/api/tests/test_data_management.py
+++ b/api/tests/test_data_management.py
@@ -1,9 +1,65 @@
 from __future__ import annotations
 
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
 import pytest
 from httpx import AsyncClient
 
 from tests.helpers import create_account, create_category, create_transaction
+
+
+def _sqlite_bytes(*, core_tables: bool, alembic_revision: str | None) -> bytes:
+    """A syntactically valid SQLite file with tunable contents."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE placeholder (id INTEGER)")
+    if core_tables:
+        conn.execute("CREATE TABLE account (id INTEGER)")
+        conn.execute('CREATE TABLE "transaction" (id INTEGER)')
+        conn.execute("CREATE TABLE category (id INTEGER)")
+    if alembic_revision is not None:
+        conn.execute("CREATE TABLE alembic_version (version_num VARCHAR(32))")
+        conn.execute("INSERT INTO alembic_version VALUES (?)", (alembic_revision,))
+    conn.commit()
+    conn.close()
+    data = Path(path).read_bytes()
+    os.unlink(path)
+    return data
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_sqlite_missing_core_tables(
+    test_app: AsyncClient,
+) -> None:
+    body = _sqlite_bytes(core_tables=False, alembic_revision=None)
+    resp = await test_app.post(
+        "/api/restore/sqlite", files={"file": ("x.sqlite", body, "x")}
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_unknown_schema_revision(test_app: AsyncClient) -> None:
+    body = _sqlite_bytes(core_tables=True, alembic_revision="zzz999notreal")
+    resp = await test_app.post(
+        "/api/restore/sqlite", files={"file": ("x.sqlite", body, "x")}
+    )
+    assert resp.status_code == 400
+    assert "revision" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_corrupt_file(test_app: AsyncClient) -> None:
+    corrupt = b"SQLite format 3\x00" + b"\x00" * 400
+    resp = await test_app.post(
+        "/api/restore/sqlite",
+        files={"file": ("x.sqlite", corrupt, "x")},
+    )
+    assert resp.status_code == 400
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #97 (review findings C11, SEC3).

## Problem
`export_sqlite` / `restore_sqlite` used `app.state.db_path` (= hard-coded `DEFAULT_DB_PATH`), not the engine's URL — with `DATABASE_URL` set, export backed up the wrong/empty file and **restore overwrote the wrong path** (latent data loss). Restore also accepted any file with a SQLite magic header.

## Change
- `db.sqlite_path_from_engine(engine)` — single source of truth for the on-disk DB file.
- `restore_sqlite`: `PRAGMA integrity_check` + required core tables + known `alembic_version` revision → **400** on failure; serialized under `app.state.restore_lock` (**409** if concurrent).

## Test plan
- [x] `make ci` green (lint, mypy, tests, coverage, no migration drift)
- [ ] CI green on GitHub

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm