### PR TITLE
feat(api): bound CSV upload size and row count (#98)

### DIFF
--- a/api/my_private_finances/api/routes/imports.py
+++ b/api/my_private_finances/api/routes/imports.py
@@ -19,6 +19,34 @@ router = APIRouter(prefix="/imports", tags=["imports"])
 
 logger = logging.getLogger(__name__)
 
+_MAX_CSV_BYTES = 20 * 1024 * 1024  # 20 MB
+_READ_CHUNK = 1 * 1024 * 1024
+
+
+def _too_large() -> HTTPException:
+    limit_mb = _MAX_CSV_BYTES // (1024 * 1024)
+    return HTTPException(
+        status_code=413, detail=f"CSV file too large (max {limit_mb} MB)"
+    )
+
+
+async def _spool_upload_to_tmp(file: UploadFile) -> tuple[Path, int]:
+    """Stream the upload to a temp file, enforcing the size cap without ever
+    holding the whole file in memory."""
+    if file.size is not None and file.size > _MAX_CSV_BYTES:
+        raise _too_large()
+
+    total = 0
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+        while chunk := await file.read(_READ_CHUNK):
+            total += len(chunk)
+            if total > _MAX_CSV_BYTES:
+                tmp_path.unlink(missing_ok=True)
+                raise _too_large()
+            tmp.write(chunk)
+    return tmp_path, total
+
 
 @router.post("/csv", response_model=ImportResultResponse)
 async def import_csv(
@@ -30,12 +58,39 @@ async def import_csv(
     decimal_comma: Annotated[bool | None, Query()] = None,
     profile_id: Annotated[int | None, Query()] = None,
 ) -> ImportResultResponse:
-    content = await file.read()
+    tmp_path, size = await _spool_upload_to_tmp(file)
+    try:
+        return await _run_import(
+            file,
+            tmp_path,
+            size,
+            session,
+            account_id,
+            delimiter,
+            date_format,
+            decimal_comma,
+            profile_id,
+        )
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+async def _run_import(
+    file: UploadFile,
+    tmp_path: Path,
+    size: int,
+    session: SessionDep,
+    account_id: int,
+    delimiter: str | None,
+    date_format: str | None,
+    decimal_comma: bool | None,
+    profile_id: int | None,
+) -> ImportResultResponse:
     logger.info(
         "CSV import request: account_id=%d, filename=%r, size=%d bytes, profile_id=%s",
         account_id,
         file.filename,
-        len(content),
+        size,
         profile_id,
     )
 
@@ -69,11 +124,7 @@ async def import_csv(
         decimal_comma if decimal_comma is not None else profile_decimal_comma
     )
 
-    tmp_path: Path | None = None
     try:
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            tmp.write(content)
-            tmp_path = Path(tmp.name)
         result = await import_transactions_from_csv_path(
             session=session,
             account_id=account_id,
@@ -91,9 +142,6 @@ async def import_csv(
         if "not found" in msg:
             raise HTTPException(status_code=404, detail=msg) from e
         raise HTTPException(status_code=400, detail=msg) from e
-    finally:
-        if tmp_path is not None:
-            tmp_path.unlink(missing_ok=True)
 
     if result.created > 0:
         try:

--- a/api/my_private_finances/services/csv_import.py
+++ b/api/my_private_finances/services/csv_import.py
@@ -121,6 +121,7 @@ async def import_transactions_from_csv_path(
     account_id: int,
     csv_path: Path,
     max_errors: int = 50,
+    max_rows: int = 100_000,
     delimiter: str = ",",
     date_format: str = "iso",
     decimal_comma: bool = False,
@@ -187,6 +188,11 @@ async def import_transactions_from_csv_path(
 
         for idx, row in enumerate(reader, start=2):
             total_rows += 1
+            if total_rows > max_rows:
+                raise ValueError(
+                    f"CSV exceeds the {max_rows:,}-row import limit; "
+                    "split the file and import in parts"
+                )
 
             if row_filters and any(
                 row.get(col, "") not in vals for col, vals in row_filters.items()

--- a/api/tests/test_import_limits.py
+++ b/api/tests/test_import_limits.py
@@ -1,0 +1,54 @@
+"""CSV import bounds — upload size and row count (issue #98)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+from my_private_finances.services.csv_import import import_transactions_from_csv_path
+from tests.helpers import create_account
+
+
+@pytest.mark.asyncio
+async def test_oversize_csv_upload_is_rejected(test_app: AsyncClient) -> None:
+    acc = await create_account(test_app)
+    oversize = b"booking_date,amount,currency,payee,purpose\n" + b"x" * (
+        21 * 1024 * 1024
+    )
+
+    res = await test_app.post(
+        f"/api/imports/csv?account_id={acc['id']}",
+        files={"file": ("big.csv", oversize, "text/csv")},
+    )
+    assert res.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_row_count_over_limit_raises_before_any_write(
+    test_app: AsyncClient, tmp_path: Path
+) -> None:
+    acc = await create_account(test_app)
+    csv_file = tmp_path / "many.csv"
+    rows = "\n".join(
+        f"2026-01-{d:02d},-1.00,EUR,Shop{d},x,ext-{d}" for d in range(1, 6)
+    )
+    csv_file.write_text(
+        "booking_date,amount,currency,payee,purpose,external_id\n" + rows + "\n",
+        encoding="utf-8",
+    )
+
+    session_factory = test_app._transport.app.state.session_factory  # type: ignore[attr-defined]
+    async with session_factory() as session:
+        with pytest.raises(ValueError, match="row"):
+            await import_transactions_from_csv_path(
+                session=session,
+                account_id=acc["id"],
+                csv_path=csv_file,
+                max_rows=2,
+            )
+
+    # Nothing was written.
+    listing = await test_app.get(f"/api/transactions?account_id={acc['id']}")
+    assert listing.json()["total"] == 0


### PR DESCRIPTION
Closes #98 (review finding SEC4).

- 20 MB upload cap, streamed to a temp file in 1 MB chunks (no more `await file.read()` of the whole body) → **413**.
- `max_rows=100_000` in the parser → **400** before any DB write.
- `import_csv` split into a wrapper + `_run_import` for guaranteed temp-file cleanup.

## Test plan
- [x] `make ci` green (lint, mypy, tests, no migration drift)
- [ ] CI green on GitHub

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm