### PR TITLE
fix: small API-correctness fixes — PATCH, filters, type drift, Decimal (#100)

### DIFF
--- a/api/my_private_finances/api/routes/transactions.py
+++ b/api/my_private_finances/api/routes/transactions.py
@@ -96,12 +96,14 @@ async def update_transaction(
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Transaction not found")
 
-    if payload.category_id is not None:
-        cat = await session.get(Category, payload.category_id)
-        if cat is None:
-            raise HTTPException(status_code=422, detail="Category not found")
+    fields = payload.model_dump(exclude_unset=True)
 
-    db_obj.category_id = payload.category_id
+    if "category_id" in fields:
+        category_id = fields["category_id"]
+        if category_id is not None and await session.get(Category, category_id) is None:
+            raise HTTPException(status_code=422, detail="Category not found")
+        db_obj.category_id = category_id
+
     await session.commit()
     await session.refresh(db_obj)
 
@@ -142,8 +144,16 @@ async def list_transactions(
         filters.append(Transaction.booking_date >= date_from)  # type: ignore[arg-type]
     if date_to is not None:
         filters.append(Transaction.booking_date <= date_to)  # type: ignore[arg-type]
-    if category_filter == "uncategorized":
-        filters.append(Transaction.category_id.is_(None))  # type: ignore[union-attr]
+    if category_filter is not None:
+        if category_filter == "uncategorized":
+            filters.append(Transaction.category_id.is_(None))  # type: ignore[union-attr]
+        elif category_filter.isdigit():
+            filters.append(Transaction.category_id == int(category_filter))  # type: ignore[arg-type]
+        else:
+            raise HTTPException(
+                status_code=422,
+                detail="category_filter must be 'uncategorized' or a category id",
+            )
     if q is not None:
         filters.append(
             or_(

--- a/api/my_private_finances/services/categorization.py
+++ b/api/my_private_finances/services/categorization.py
@@ -69,6 +69,8 @@ def _match_amount(amount: Decimal, operator: str, value: str) -> bool:
         threshold = Decimal(value)
     except InvalidOperation:
         return False
+    if not threshold.is_finite():
+        return False
     op = _AMOUNT_OPS.get(operator)
     if op is None:
         logger.warning("Unknown amount operator: %r", operator)

--- a/api/my_private_finances/services/csv_import.py
+++ b/api/my_private_finances/services/csv_import.py
@@ -86,9 +86,12 @@ def _parse_decimal(value: str, *, decimal_comma: bool) -> Decimal:
     raw = value.strip()
     normalized = raw.replace(".", "").replace(",", ".") if decimal_comma else raw
     try:
-        return Decimal(normalized)
+        parsed = Decimal(normalized)
     except InvalidOperation:
         raise ValueError(f"Invalid decimal value: '{raw}'")
+    if not parsed.is_finite():
+        raise ValueError(f"Non-finite decimal value: '{raw}'")
+    return parsed
 
 
 def _row_fingerprint(row: dict[str, Any]) -> str:

--- a/api/tests/test_csv_parsing_units.py
+++ b/api/tests/test_csv_parsing_units.py
@@ -1,0 +1,18 @@
+"""Unit tests for the CSV value parsers (issue #100, finding C12)."""
+
+from __future__ import annotations
+
+import pytest
+
+from my_private_finances.services.csv_import import _parse_decimal
+
+
+@pytest.mark.parametrize("value", ["NaN", "nan", "Infinity", "-Infinity", "inf"])
+def test_parse_decimal_rejects_non_finite(value: str) -> None:
+    with pytest.raises(ValueError):
+        _parse_decimal(value, decimal_comma=False)
+
+
+def test_parse_decimal_accepts_normal_values() -> None:
+    assert str(_parse_decimal("-12.34", decimal_comma=False)) == "-12.34"
+    assert str(_parse_decimal("1.234,56", decimal_comma=True)) == "1234.56"

--- a/api/tests/test_transactions_search.py
+++ b/api/tests/test_transactions_search.py
@@ -196,3 +196,36 @@ async def test_search_combined_with_account(test_app: AsyncClient) -> None:
     body = res.json()
     assert body["total"] == 1
     assert body["items"][0]["account_id"] == acc1["id"]
+
+
+@pytest.mark.asyncio
+async def test_filter_by_category_id(test_app: AsyncClient) -> None:
+    from tests.helpers import create_category
+
+    acc = await create_account(test_app)
+    food = await create_category(test_app, name="Food")
+    rent = await create_category(test_app, name="Rent")
+    t1 = await create_transaction(test_app, account_id=acc["id"], external_id="c1")
+    await create_transaction(test_app, account_id=acc["id"], external_id="c2")
+    await test_app.patch(
+        f"/api/transactions/{t1['id']}", json={"category_id": food["id"]}
+    )
+
+    res = await test_app.get(
+        "/api/transactions", params={"category_filter": str(food["id"])}
+    )
+    assert res.status_code == 200
+    assert res.json()["total"] == 1
+
+    empty = await test_app.get(
+        "/api/transactions", params={"category_filter": str(rent["id"])}
+    )
+    assert empty.json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_invalid_category_filter_is_422(test_app: AsyncClient) -> None:
+    res = await test_app.get(
+        "/api/transactions", params={"category_filter": "not-a-thing"}
+    )
+    assert res.status_code == 422

--- a/api/tests/test_transactions_update.py
+++ b/api/tests/test_transactions_update.py
@@ -39,6 +39,22 @@ async def test_patch_transaction_clears_category(test_app: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_patch_transaction_empty_body_keeps_category(
+    test_app: AsyncClient,
+) -> None:
+    acc = await create_account(test_app)
+    cat = await create_category(test_app, name="Groceries")
+    tx = await create_transaction(test_app, account_id=acc["id"])
+    await test_app.patch(
+        f"/api/transactions/{tx['id']}", json={"category_id": cat["id"]}
+    )
+
+    res = await test_app.patch(f"/api/transactions/{tx['id']}", json={})
+    assert res.status_code == 200
+    assert res.json()["category_id"] == cat["id"]
+
+
+@pytest.mark.asyncio
 async def test_patch_transaction_not_found(test_app: AsyncClient) -> None:
     res = await test_app.patch("/api/transactions/99999", json={"category_id": None})
     assert res.status_code == 404

--- a/app/src/lib/api/imports.ts
+++ b/app/src/lib/api/imports.ts
@@ -12,6 +12,7 @@ export type ImportErrorDetail = {
 export type ImportResult = {
   total_rows: number;
   created: number;
+  skipped: number;
   duplicates: number;
   failed: number;
   errors: ImportErrorDetail[];

--- a/app/tests/components/ImportResult.test.tsx
+++ b/app/tests/components/ImportResult.test.tsx
@@ -6,6 +6,7 @@ import type { ImportResult as ImportResultType } from "../../src/lib/api";
 const successResult: ImportResultType = {
   total_rows: 10,
   created: 8,
+  skipped: 0,
   duplicates: 2,
   failed: 0,
   errors: [],
@@ -15,6 +16,7 @@ const successResult: ImportResultType = {
 const resultWithErrors: ImportResultType = {
   total_rows: 5,
   created: 2,
+  skipped: 0,
   duplicates: 1,
   failed: 2,
   errors: [


### PR DESCRIPTION
Closes #100 (review findings C7, C8, C9, C12).

- **C7** `update_transaction`: `exclude_unset` — `PATCH {}` no longer clears the category.
- **C8** `list_transactions`: `category_filter` accepts a category id; unknown value → 422.
- **C9** frontend `ImportResult` type gains `skipped`.
- **C12** `_parse_decimal` / `_match_amount` reject `NaN`/`Infinity`.

**SEC8 deferred** — sha1→sha256 on the row fingerprint changes the fallback `external_id` and breaks import idempotency for existing rows; needs its own migration.

## Test plan
- [x] backend `make ci` green (mypy, tests, no migration drift)
- [x] frontend typecheck + vitest green
- [ ] CI green on GitHub

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm