### PR TITLE
fix(api): clean money precision in SQL aggregation (#111)

### DIFF
--- a/api/my_private_finances/api/routes/annual.py
+++ b/api/my_private_finances/api/routes/annual.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, Optional, cast
 from fastapi import APIRouter, Query
 from sqlalchemy import select
 
+from my_private_finances.utils.money import money_from_db
 from my_private_finances.api.routes.reports import _resolve_currency
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Transaction
@@ -51,7 +52,7 @@ async def get_annual_report(
     for row in rows:
         bdate: date = row.booking_date
         month_str = f"{bdate.year}-{bdate.month:02d}"
-        amount = Decimal(str(row.amount))
+        amount = money_from_db(row.amount)
         if amount > _ZERO:
             income_by_month[month_str] = income_by_month.get(month_str, _ZERO) + amount
         else:

--- a/api/my_private_finances/api/routes/net_worth.py
+++ b/api/my_private_finances/api/routes/net_worth.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter
 from fastapi.params import Query
 from sqlalchemy import select
 
+from my_private_finances.utils.money import money_from_db
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Account, Transaction
 from my_private_finances.schemas import (
@@ -100,7 +101,7 @@ async def get_net_worth(
     }  # type: ignore[misc]
     for row in tx_rows:
         tx_by_account[row.account_id].append(
-            (row.booking_date, Decimal(str(row.amount)))
+            (row.booking_date, money_from_db(row.amount))
         )
 
     # Build monthly balance series per account

--- a/api/my_private_finances/api/routes/recurring_patterns.py
+++ b/api/my_private_finances/api/routes/recurring_patterns.py
@@ -9,6 +9,7 @@ from fastapi.params import Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from my_private_finances.utils.money import money_from_db
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Category, RecurringPattern
 from my_private_finances.utils.db_helpers import get_account_or_404
@@ -159,7 +160,7 @@ async def get_recurring_summary(
     pattern_count = 0
 
     for r in rows:
-        freq_total = Decimal(str(r.total))
+        freq_total = money_from_db(r.total)
         count = int(r.pattern_count)
         pattern_count += count
         by_frequency.append(

--- a/api/my_private_finances/api/routes/reports.py
+++ b/api/my_private_finances/api/routes/reports.py
@@ -9,6 +9,7 @@ from fastapi.params import Query
 from sqlalchemy import func, literal, select, case
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from my_private_finances.utils.money import money_from_db
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Account, Budget, Category, Transaction
 from my_private_finances.schemas import (
@@ -84,9 +85,9 @@ async def get_monthly_report(
 
     totals_row = (await session.execute(stmt_totals)).one()
     tx_count = int(totals_row.tx_count)
-    net_total = Decimal(str(totals_row.net_total))
-    income_total = Decimal(str(totals_row.income_total))
-    expense_total = Decimal(str(totals_row.expense_total))
+    net_total = money_from_db(totals_row.net_total)
+    income_total = money_from_db(totals_row.income_total)
+    expense_total = money_from_db(totals_row.expense_total)
 
     stmt_payees = (
         select(
@@ -102,7 +103,7 @@ async def get_monthly_report(
 
     payees_rows = (await session.execute(stmt_payees)).all()
     payees = [
-        PayeeTotal(payee=r.payee, total=Decimal(str(r.total))) for r in payees_rows
+        PayeeTotal(payee=r.payee, total=money_from_db(r.total)) for r in payees_rows
     ]
 
     cat = cast(Any, Category).__table__
@@ -122,7 +123,7 @@ async def get_monthly_report(
     categories = [
         CategoryTotal(
             category_name=r.category_name,
-            total=Decimal(str(r.total)),
+            total=money_from_db(r.total),
         )
         for r in cat_rows
     ]
@@ -148,7 +149,7 @@ async def get_monthly_report(
             booking_date=r.booking_date,
             payee=r.payee,
             purpose=r.purpose,
-            amount=Decimal(str(r.amount)),
+            amount=money_from_db(r.amount),
             category_name=r.category_name,
         )
         for r in spending_rows
@@ -219,13 +220,13 @@ async def get_budget_vs_actual(
         .group_by(tx.c.category_id)
     )
     actual_rows = (await session.execute(stmt_actuals)).all()
-    actuals = {r.category_id: Decimal(str(r.actual)) for r in actual_rows}
+    actuals = {r.category_id: money_from_db(r.actual) for r in actual_rows}
 
     result = []
     for row in budget_rows:
         raw_actual = actuals.get(row.category_id, Decimal("0"))
         actual = abs(raw_actual)
-        budgeted = Decimal(str(row.budgeted))
+        budgeted = money_from_db(row.budgeted)
         result.append(
             BudgetComparison(
                 category_id=row.category_id,
@@ -276,7 +277,7 @@ async def get_fixed_vs_variable(
     totals: dict[str | None, Decimal] = {}
     breakdown: list[CostTypeBreakdown] = []
     for r in rows:
-        total = abs(Decimal(str(r.total)))
+        total = abs(money_from_db(r.total))
         totals[r.cost_type] = total
         breakdown.append(
             CostTypeBreakdown(

--- a/api/my_private_finances/api/routes/trends.py
+++ b/api/my_private_finances/api/routes/trends.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any, Optional, cast
 from fastapi import APIRouter, Query
 from sqlalchemy import select
 
+from my_private_finances.utils.money import money_from_db
 from my_private_finances.api.routes.reports import _parse_month, _resolve_currency
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Category, Transaction
@@ -81,7 +82,7 @@ async def get_spending_trend(
         bdate: date = row.booking_date
         cat_id: int | None = row.category_id
         cat_name: str | None = row.category_name
-        amount = Decimal(str(row.amount))
+        amount = money_from_db(row.amount)
 
         cat_names[cat_id] = cat_name
 

--- a/api/my_private_finances/services/recurring_detection.py
+++ b/api/my_private_finances/services/recurring_detection.py
@@ -12,6 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from my_private_finances.models import RecurringPattern, Transaction
+from my_private_finances.utils.money import money_from_db
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +173,7 @@ async def fetch_transaction_groups(
     groups: dict[str, list[tuple[date, Decimal, int | None]]] = {}
     for r in rows:
         payee = str(r.norm_payee)
-        entry = (r.booking_date, Decimal(str(r.amount)), r.category_id)
+        entry = (r.booking_date, money_from_db(r.amount), r.category_id)
         groups.setdefault(payee, []).append(entry)
 
     return groups

--- a/api/my_private_finances/services/transfer_detection.py
+++ b/api/my_private_finances/services/transfer_detection.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from my_private_finances.models import Account, Transaction
+from my_private_finances.utils.money import money_from_db
 from my_private_finances.models.transfer_candidate import TransferCandidate
 
 logger = logging.getLogger(__name__)
@@ -71,7 +72,7 @@ async def detect_transfer_candidates(
     window = timedelta(days=window_days)
 
     for out_tx in outgoing:
-        out_abs = abs(Decimal(str(out_tx.amount)))
+        out_abs = abs(money_from_db(out_tx.amount))
 
         for in_tx in incoming:
             # Must be different accounts
@@ -79,7 +80,7 @@ async def detect_transfer_candidates(
                 continue
 
             # Amount must match exactly
-            in_abs = Decimal(str(in_tx.amount))
+            in_abs = money_from_db(in_tx.amount)
             if out_abs != in_abs:
                 continue
 

--- a/api/my_private_finances/utils/money.py
+++ b/api/my_private_finances/utils/money.py
@@ -1,0 +1,21 @@
+"""Money helpers (issue #111 / review finding C3).
+
+SQLite stores ``Numeric`` as REAL, so ``SUM(amount)`` comes back as a float and
+the reporting code used ``Decimal(str(x))`` in ~18 places. Quantising to cents
+absorbs the float-representation noise; the accumulated error from summing
+2-decimal values in float stays many orders of magnitude below half a cent for
+any realistic transaction count.
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+CENTS = Decimal("0.01")
+
+
+def money_from_db(value: object) -> Decimal:
+    """Coerce a raw DB numeric/aggregate to a clean 2-decimal ``Decimal``."""
+    if value is None:
+        return Decimal("0.00")
+    return Decimal(str(value)).quantize(CENTS, rounding=ROUND_HALF_UP)

--- a/api/tests/test_money.py
+++ b/api/tests/test_money.py
@@ -1,0 +1,39 @@
+"""Money precision in reporting (issue #111 / finding C3)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+
+from my_private_finances.utils.money import money_from_db
+from tests.helpers import create_account, create_transaction
+
+
+def test_money_from_db_absorbs_float_noise() -> None:
+    assert money_from_db(0.1 + 0.2) == Decimal("0.30")
+    assert money_from_db(None) == Decimal("0.00")
+    assert money_from_db(Decimal("12.34")) == Decimal("12.34")
+
+
+@pytest.mark.asyncio
+async def test_monthly_report_sum_is_exact_to_the_cent(test_app: AsyncClient) -> None:
+    acc = await create_account(test_app)
+    for i, amount in enumerate(["-0.10", "-0.20", "-0.10"]):
+        await create_transaction(
+            test_app,
+            account_id=acc["id"],
+            booking_date="2026-03-05",
+            amount=amount,
+            external_id=f"m{i}",
+        )
+
+    body = (
+        await test_app.get(
+            "/api/reports/monthly",
+            params={"month": "2026-03", "account_id": acc["id"]},
+        )
+    ).json()
+    assert body["expense_total"] == "-0.40"
+    assert body["net_total"] == "-0.40"


### PR DESCRIPTION
Closes #111 (review finding C3).

SQLite stores `Numeric` as REAL → `SUM(amount)` is a float → `Decimal(str(x))` carried the noise through. A monthly total could be a cent off.

- `utils/money.py::money_from_db()` — quantise to cents (the accumulated float error in summing 2-dp values stays orders of magnitude below half a cent).
- 16 money `Decimal(str(...))` sites replaced; 2 non-money uses left.
- Test: monthly report over `-0.10, -0.20, -0.10` → exactly `-0.40`.

## Test plan
- [x] `make ci` green (lint, mypy, 245+ tests, no migration drift)
- [ ] CI green on GitHub

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm