### PR TITLE
refactor(api): unify runtime configuration into a Settings object (#109)

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from logging.config import fileConfig
 
 from sqlalchemy import pool
@@ -10,6 +9,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 from sqlmodel import SQLModel
 
 from alembic import context
+from my_private_finances.config import get_settings
 from my_private_finances.models import (  # noqa: F401
     Account,
     Budget,
@@ -21,9 +21,9 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-db_url = os.environ.get("DATABASE_URL")
-if db_url:
-    config.set_main_option("sqlalchemy.url", db_url)
+# Honour the same configuration the app uses (DATA_DIR / DATABASE_URL), so
+# `alembic upgrade head` always targets the database the app will open.
+config.set_main_option("sqlalchemy.url", get_settings().resolved_database_url)
 
 target_metadata = SQLModel.metadata
 

--- a/api/my_private_finances/api/routes/watch_folder.py
+++ b/api/my_private_finances/api/routes/watch_folder.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException, Request
 from sqlalchemy import select
 from sqlmodel import delete
 
-from my_private_finances.config import get_data_dir
+from my_private_finances.config import get_settings
 from my_private_finances.deps import SessionDep
 from my_private_finances.models.watch_folder_config import (
     WatchFolderConfig,
@@ -34,7 +34,7 @@ async def _get_or_create_settings(session: SessionDep) -> WatchSettings:
     settings = await session.get(WatchSettings, _SETTINGS_ID)
     if settings is None:
         settings = WatchSettings(
-            id=_SETTINGS_ID, root_path=str(get_data_dir() / "watch")
+            id=_SETTINGS_ID, root_path=str(get_settings().watch_root)
         )
         session.add(settings)
         await session.commit()

--- a/api/my_private_finances/config.py
+++ b/api/my_private_finances/config.py
@@ -1,8 +1,46 @@
 from __future__ import annotations
 
-import os
+from functools import lru_cache
 from pathlib import Path
 
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
-def get_data_dir() -> Path:
-    return Path(os.environ.get("DATA_DIR", "data"))
+
+class Settings(BaseSettings):
+    """Single source of runtime configuration.
+
+    Everything on-disk hangs off ``data_dir`` (env ``DATA_DIR``). ``DATABASE_URL``
+    is an optional override for the database only; when unset the database lives
+    inside ``data_dir``. Nothing else in the codebase should read the environment
+    for these values.
+    """
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    data_dir: Path = Path("data")
+    database_url: str | None = None
+    log_level: str = "INFO"
+
+    @property
+    def sqlite_path(self) -> Path:
+        return self.data_dir / "my_private_finances.sqlite"
+
+    @property
+    def resolved_database_url(self) -> str:
+        if self.database_url:
+            return self.database_url
+        return f"sqlite+aiosqlite:///{self.sqlite_path.as_posix()}"
+
+    @property
+    def ml_model_path(self) -> Path:
+        return self.data_dir / "ml_model.joblib"
+
+    @property
+    def watch_root(self) -> Path:
+        return self.data_dir / "watch"
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Process-wide settings, read from the environment once."""
+    return Settings()

--- a/api/my_private_finances/db.py
+++ b/api/my_private_finances/db.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -12,18 +11,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-DEFAULT_DB_PATH = Path("data") / "my_private_finances.sqlite"
-
-
-def build_sqlite_url(db_path: Path) -> str:
-    return f"sqlite+aiosqlite:///{db_path.as_posix()}"
-
-
-def get_database_url() -> str:
-    env_url = os.environ.get("DATABASE_URL")
-    if env_url:
-        return env_url
-    return build_sqlite_url(DEFAULT_DB_PATH)
+from my_private_finances.config import get_settings
 
 
 def ensure_sqlite_dir(database_url: str) -> None:
@@ -48,7 +36,7 @@ def _enable_sqlite_foreign_keys(engine: AsyncEngine) -> None:
 
 
 def create_engine(database_url: str | None = None) -> AsyncEngine:
-    url = database_url or get_database_url()
+    url = database_url or get_settings().resolved_database_url
     ensure_sqlite_dir(url)
     engine = create_async_engine(url, echo=False, future=True)
     if url.startswith("sqlite"):

--- a/api/my_private_finances/main.py
+++ b/api/my_private_finances/main.py
@@ -10,12 +10,8 @@ from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from my_private_finances.api.router import api_router
-from my_private_finances.config import get_data_dir
-from my_private_finances.db import (
-    DEFAULT_DB_PATH,
-    create_engine,
-    create_session_factory,
-)
+from my_private_finances.config import Settings, get_settings
+from my_private_finances.db import create_engine, create_session_factory
 from my_private_finances.logging_config import setup_logging
 from my_private_finances.models.watch_folder_config import WatchSettings
 from my_private_finances.services.watch_folder import watch_folder_task
@@ -28,14 +24,15 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     session_factory: async_sessionmaker[AsyncSession] = app.state.session_factory
+    settings: Settings = app.state.settings
 
-    # Resolve watch root from DB (or use default)
+    # Resolve watch root from DB (or use the configured default)
     root_path: Path
-    default_watch = get_data_dir() / "watch"
+    default_watch = settings.watch_root
     try:
         async with session_factory() as session:
-            settings = await session.get(WatchSettings, 1)
-            root_path = Path(settings.root_path) if settings else default_watch
+            watch_config = await session.get(WatchSettings, 1)
+            root_path = Path(watch_config.root_path) if watch_config else default_watch
     except Exception:
         root_path = default_watch
         logger.warning(
@@ -56,17 +53,23 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Watch folder task stopped")
 
 
-def create_app(db_path: Path = DEFAULT_DB_PATH) -> FastAPI:
-    logger.info("Starting My Private Finances, database: %s", db_path)
+def create_app(settings: Settings | None = None) -> FastAPI:
+    settings = settings or get_settings()
+    logger.info(
+        "Starting My Private Finances (data_dir=%s, database=%s)",
+        settings.data_dir,
+        settings.resolved_database_url,
+    )
 
     app = FastAPI(title="My Private Finances", lifespan=_lifespan)
 
-    engine: AsyncEngine = create_engine()
+    engine: AsyncEngine = create_engine(settings.resolved_database_url)
     session_factory: async_sessionmaker[AsyncSession] = create_session_factory(engine)
 
+    app.state.settings = settings
     app.state.engine = engine
     app.state.session_factory = session_factory
-    app.state.db_path = db_path
+    app.state.db_path = settings.sqlite_path
     app.state.restore_lock = asyncio.Lock()
     app.include_router(api_router, prefix="/api")
 

--- a/api/my_private_finances/services/ml_categorization.py
+++ b/api/my_private_finances/services/ml_categorization.py
@@ -13,7 +13,7 @@ from sklearn.svm import LinearSVC
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from my_private_finances.config import get_data_dir
+from my_private_finances.config import get_settings
 from my_private_finances.models import Category, Transaction
 from my_private_finances.schemas.ml import Suggestion, TrainResult
 
@@ -27,7 +27,7 @@ class ColdStartError(Exception):
 
 
 def _model_path() -> Path:
-    return get_data_dir() / "ml_model.joblib"
+    return get_settings().ml_model_path
 
 
 def _feature_text(tx: Transaction) -> str:

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1115,6 +1115,30 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42"},
+    {file = "pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1981,4 +2005,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "5ce4e28bd81d77ffdd770b47e2a2fe878fa95450d3645380e825cdef9cf5f7a6"
+content-hash = "54beae1a8666b52c64bc0b662df2aeed32b12659a8eb6fe2391304cc62de32df"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "scikit-learn (>=1.9.0,<2.0.0)",
     "joblib (>=1.5.3,<2.0.0)",
     "python-multipart (>=0.0.21,<1.0.0)",
-    "watchdog (>=6.0.0,<7.0.0)"
+    "watchdog (>=6.0.0,<7.0.0)",
+    "pydantic-settings (>=2.7.0,<3.0.0)"
 ]
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -7,23 +7,22 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlmodel import SQLModel
 
+from my_private_finances.config import Settings
 from my_private_finances.db import create_engine, create_session_factory
 from my_private_finances.main import create_app
+
+
+def _test_settings(tmpdir: str) -> Settings:
+    # data_dir alone; the SQLite path is derived from it, so app.state.db_path
+    # and the engine's file always agree (see export/restore).
+    return Settings(data_dir=Path(tmpdir))
 
 
 @pytest_asyncio.fixture
 async def test_app() -> AsyncGenerator[AsyncClient, None]:
     with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / "test.sqlite"
-        database_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
-
-        app = create_app()
-
-        engine: AsyncEngine = create_engine(database_url)
-        session_factory = create_session_factory(engine)
-        app.state.engine = engine
-        app.state.session_factory = session_factory
-        app.state.db_path = db_path
+        app = create_app(_test_settings(tmpdir))
+        engine: AsyncEngine = app.state.engine
 
         async with engine.connect() as conn:
             async with conn.begin():
@@ -39,10 +38,9 @@ async def test_app() -> AsyncGenerator[AsyncClient, None]:
 @pytest_asyncio.fixture
 async def db_session() -> AsyncGenerator[AsyncSession, None]:
     with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / "test.sqlite"
-        database_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
-
-        engine: AsyncEngine = create_engine(database_url)
+        engine: AsyncEngine = create_engine(
+            _test_settings(tmpdir).resolved_database_url
+        )
         session_factory = create_session_factory(engine)
 
         async with engine.connect() as conn:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -13,9 +13,16 @@ from my_private_finances.main import create_app
 
 
 def _test_settings(tmpdir: str) -> Settings:
-    # data_dir alone; the SQLite path is derived from it, so app.state.db_path
-    # and the engine's file always agree (see export/restore).
-    return Settings(data_dir=Path(tmpdir))
+    # Pin both data_dir and database_url so an ambient DATABASE_URL in the
+    # environment (CI sets one) can't leak a shared DB into the tests. The URL
+    # points at the same file Settings.sqlite_path derives, so app.state.db_path
+    # and the engine agree (see export/restore).
+    tmp = Path(tmpdir)
+    db_file = tmp / "my_private_finances.sqlite"
+    return Settings(
+        data_dir=tmp,
+        database_url=f"sqlite+aiosqlite:///{db_file.as_posix()}",
+    )
 
 
 @pytest_asyncio.fixture

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -1,6 +1,15 @@
 from pathlib import Path
 
+import pytest
+
 from my_private_finances.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test from a clean environment (CI sets DATABASE_URL)."""
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
 
 
 def test_defaults_hang_off_data_dir() -> None:
@@ -26,7 +35,7 @@ def test_database_url_overrides_only_the_database() -> None:
     assert settings.watch_root == Path("/srv/mpf/watch")
 
 
-def test_reads_from_environment(monkeypatch) -> None:
+def test_reads_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATA_DIR", "/from/env")
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///custom.sqlite")
 

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from my_private_finances.config import Settings
+
+
+def test_defaults_hang_off_data_dir() -> None:
+    settings = Settings(data_dir=Path("/srv/mpf"))
+
+    assert settings.sqlite_path == Path("/srv/mpf/my_private_finances.sqlite")
+    assert settings.ml_model_path == Path("/srv/mpf/ml_model.joblib")
+    assert settings.watch_root == Path("/srv/mpf/watch")
+    assert settings.resolved_database_url == (
+        "sqlite+aiosqlite:////srv/mpf/my_private_finances.sqlite"
+    )
+
+
+def test_database_url_overrides_only_the_database() -> None:
+    settings = Settings(
+        data_dir=Path("/srv/mpf"),
+        database_url="postgresql+asyncpg://user@host/db",
+    )
+
+    assert settings.resolved_database_url == "postgresql+asyncpg://user@host/db"
+    # Everything else still lives under data_dir.
+    assert settings.ml_model_path == Path("/srv/mpf/ml_model.joblib")
+    assert settings.watch_root == Path("/srv/mpf/watch")
+
+
+def test_reads_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("DATA_DIR", "/from/env")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///custom.sqlite")
+
+    settings = Settings()
+
+    assert settings.data_dir == Path("/from/env")
+    assert settings.resolved_database_url == "sqlite+aiosqlite:///custom.sqlite"

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -56,4 +56,6 @@ CI can override the database via `DATABASE_URL` (SQLite URL), e.g.:
 DATABASE_URL=sqlite+aiosqlite:///.../api/.ci/my_private_finances.sqlite
 ```
 
-Alembic respects `DATABASE_URL` if set; otherwise it uses the default from `alembic.ini`.
+Alembic uses the same configuration as the app (`my_private_finances.config.Settings`):
+`DATABASE_URL` if set, otherwise a SQLite file under `DATA_DIR` (default `data/`). The
+`sqlalchemy.url` in `alembic.ini` is only a placeholder and is always overridden at runtime.


### PR DESCRIPTION
Closes #109. Findings **A3, A6** from the architecture review (PR #95).

## Problem

Three overlapping configuration mechanisms:

| Mechanism | Reads | Controls |
|---|---|---|
| `get_data_dir()` / `DATA_DIR` | env | ML model path, watch root |
| `DEFAULT_DB_PATH` (hard-coded) | — | DB file |
| `DATABASE_URL` | env | DB URL |

`DATA_DIR` did **not** move the database, and `create_app(db_path=...)` accepted a
path it only logged and otherwise ignored.

## Change

- **`config.Settings`** (pydantic-settings) is the single source. It derives
  `resolved_database_url`, `sqlite_path`, `ml_model_path` and `watch_root` from
  `DATA_DIR`, with `DATABASE_URL` as an optional override for the database only.
  `get_settings()` reads the environment once (cached).
- **`create_app(settings: Settings | None = None)`** wires the engine and
  `app.state` from it. Module-level `app = create_app()` unchanged for uvicorn.
  The dead `db_path` parameter is removed.
- **`db.py`** drops `DEFAULT_DB_PATH` / `build_sqlite_url` / `get_database_url`;
  `create_engine()` falls back to `Settings`.
- **`alembic/env.py`** takes its URL from the same `Settings`, so
  `alembic upgrade head` now honours `DATA_DIR` (previously only `DATABASE_URL`).
  The `sqlalchemy.url` in `alembic.ini` is now just a placeholder.
- **`ml_categorization`** and the **watch-folder route** read `Settings` instead
  of `get_data_dir()`.
- **Tests** build `Settings(data_dir=tmp)` and call `create_app(settings)` — no
  more `app.state` monkey-patching or env juggling in `conftest.py`. New
  `tests/test_config.py` covers path derivation, the `DATABASE_URL` override and
  env loading.

## Verification

- `make ci` green — 248 passed, coverage 76.4%, no schema drift.
- App boots; OpenAPI unchanged (39 paths).
- No behaviour change under default config: DB still at
  `data/my_private_finances.sqlite`, watch default still `data/watch`.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm