### PR TITLE
fix(api): sort money_from_db imports (unbreak main lint)

### DIFF
--- a/api/my_private_finances/api/routes/annual.py
+++ b/api/my_private_finances/api/routes/annual.py
@@ -7,11 +7,11 @@ from typing import Annotated, Any, Optional, cast
 from fastapi import APIRouter, Query
 from sqlalchemy import select
 
-from my_private_finances.utils.money import money_from_db
 from my_private_finances.api.routes.reports import _resolve_currency
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Transaction
 from my_private_finances.schemas import AnnualReport, MonthSummary
+from my_private_finances.utils.money import money_from_db
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 

--- a/api/my_private_finances/api/routes/net_worth.py
+++ b/api/my_private_finances/api/routes/net_worth.py
@@ -18,7 +18,6 @@ from fastapi import APIRouter
 from fastapi.params import Query
 from sqlalchemy import select
 
-from my_private_finances.utils.money import money_from_db
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Account, Transaction
 from my_private_finances.schemas import (
@@ -27,6 +26,7 @@ from my_private_finances.schemas import (
     NetWorthPoint,
     NetWorthReport,
 )
+from my_private_finances.utils.money import money_from_db
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 

--- a/api/my_private_finances/api/routes/recurring_patterns.py
+++ b/api/my_private_finances/api/routes/recurring_patterns.py
@@ -9,7 +9,6 @@ from fastapi.params import Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from my_private_finances.utils.money import money_from_db
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Category, RecurringPattern
 from my_private_finances.schemas import (
@@ -20,6 +19,7 @@ from my_private_finances.schemas import (
 )
 from my_private_finances.services.recurring_detection import run_detection
 from my_private_finances.utils.db_helpers import get_account_or_404
+from my_private_finances.utils.money import money_from_db
 
 router = APIRouter(prefix="/recurring-patterns", tags=["recurring-patterns"])
 

--- a/api/my_private_finances/api/routes/reports.py
+++ b/api/my_private_finances/api/routes/reports.py
@@ -9,7 +9,6 @@ from fastapi.params import Query
 from sqlalchemy import case, func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from my_private_finances.utils.money import money_from_db
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Account, Budget, Category, Transaction
 from my_private_finances.schemas import (
@@ -21,6 +20,7 @@ from my_private_finances.schemas import (
     PayeeTotal,
     TopSpending,
 )
+from my_private_finances.utils.money import money_from_db
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 

--- a/api/my_private_finances/api/routes/trends.py
+++ b/api/my_private_finances/api/routes/trends.py
@@ -8,11 +8,11 @@ from typing import Annotated, Any, Optional, cast
 from fastapi import APIRouter, Query
 from sqlalchemy import select
 
-from my_private_finances.utils.money import money_from_db
 from my_private_finances.api.routes.reports import _parse_month, _resolve_currency
 from my_private_finances.deps import SessionDep
 from my_private_finances.models import Category, Transaction
 from my_private_finances.schemas import CategoryTrendItem, SpendingTrendReport
+from my_private_finances.utils.money import money_from_db
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 

--- a/api/my_private_finances/services/transfer_detection.py
+++ b/api/my_private_finances/services/transfer_detection.py
@@ -19,8 +19,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from my_private_finances.models import Account, Transaction
-from my_private_finances.utils.money import money_from_db
 from my_private_finances.models.transfer_candidate import TransferCandidate
+from my_private_finances.utils.money import money_from_db
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
`origin/main` CI is currently **failing**: PR #124 added `from my_private_finances.utils.money import money_from_db` at the top of the first-party import block in 6 modules, which Ruff's import sort (`I001`) rejects, so `make ci` → `make lint` exits 2.

Affected: `annual.py`, `net_worth.py`, `recurring_patterns.py`, `reports.py`, `trends.py`, `services/transfer_detection.py`.

Fix is purely `ruff check --select I --fix` — the import moves to its alphabetical slot, no code change. 6 files, 1 line each.

Merge this first; then #126 rebases cleanly on a green main.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm