### PR TITLE
refactor(api): extract services/reporting.py; dedupe report filters (#104)

### DIFF
--- a/api/my_private_finances/api/routes/annual.py
+++ b/api/my_private_finances/api/routes/annual.py
@@ -1,108 +1,20 @@
 from __future__ import annotations
 
-from datetime import date
-from decimal import Decimal
-from typing import Annotated, Any, Optional, cast
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, Query
-from sqlalchemy import select
 
-from my_private_finances.api.routes.reports import _resolve_currency
 from my_private_finances.deps import SessionDep
-from my_private_finances.models import Transaction
-from my_private_finances.schemas import AnnualReport, MonthSummary
-from my_private_finances.utils.money import money_from_db
+from my_private_finances.schemas import AnnualReport
+from my_private_finances.services import reporting
 
 router = APIRouter(prefix="/reports", tags=["reports"])
-
-_ZERO = Decimal("0")
-_HUNDRED = Decimal("100")
 
 
 @router.get("/annual", response_model=AnnualReport)
 async def get_annual_report(
     session: SessionDep,
-    year: Annotated[int, Query(ge=2000, le=2100)] = None,  # type: ignore[assignment]
+    year: Annotated[Optional[int], Query(ge=2000, le=2100)] = None,
     account_id: Annotated[Optional[int], Query(ge=1)] = None,
 ) -> AnnualReport:
-    if year is None:
-        year = date.today().year
-
-    year_start = date(year, 1, 1)
-    year_end = date(year + 1, 1, 1)
-    currency = await _resolve_currency(session, account_id)
-
-    tx = cast(Any, Transaction).__table__
-
-    transfer_filter = tx.c.is_transfer == False  # noqa: E712
-    date_filter = (tx.c.booking_date >= year_start) & (tx.c.booking_date < year_end)
-
-    if account_id is not None:
-        base_filter = (tx.c.account_id == account_id) & date_filter & transfer_filter
-    else:
-        base_filter = date_filter & transfer_filter
-
-    stmt = select(tx.c.booking_date, tx.c.amount).where(base_filter)
-    rows = (await session.execute(stmt)).all()
-
-    # Aggregate per month
-    income_by_month: dict[str, Decimal] = {}
-    expenses_by_month: dict[str, Decimal] = {}
-
-    for row in rows:
-        bdate: date = row.booking_date
-        month_str = f"{bdate.year}-{bdate.month:02d}"
-        amount = money_from_db(row.amount)
-        if amount > _ZERO:
-            income_by_month[month_str] = income_by_month.get(month_str, _ZERO) + amount
-        else:
-            expenses_by_month[month_str] = expenses_by_month.get(
-                month_str, _ZERO
-            ) + abs(amount)
-
-    # Build all 12 months
-    months: list[MonthSummary] = []
-    for m in range(1, 13):
-        month_str = f"{year}-{m:02d}"
-        income = income_by_month.get(month_str, _ZERO)
-        expenses = expenses_by_month.get(month_str, _ZERO)
-        net = income - expenses
-        savings_rate = (
-            (net / income * _HUNDRED).quantize(Decimal("0.01"))
-            if income > _ZERO
-            else _ZERO.quantize(Decimal("0.01"))
-        )
-        months.append(
-            MonthSummary(
-                month=month_str,
-                income=income.quantize(Decimal("0.01")),
-                expenses=expenses.quantize(Decimal("0.01")),
-                net=net.quantize(Decimal("0.01")),
-                savings_rate=savings_rate,
-            )
-        )
-
-    total_income = sum((m.income for m in months), _ZERO)
-    total_expenses = sum((m.expenses for m in months), _ZERO)
-    total_net = total_income - total_expenses
-
-    months_with_income = [m for m in months if m.income > _ZERO]
-    avg_savings_rate = (
-        (
-            sum((m.savings_rate for m in months_with_income), _ZERO)
-            / Decimal(len(months_with_income))
-        ).quantize(Decimal("0.01"))
-        if months_with_income
-        else _ZERO
-    )
-
-    return AnnualReport(
-        year=year,
-        account_id=account_id,
-        currency=currency,
-        total_income=total_income.quantize(Decimal("0.01")),
-        total_expenses=total_expenses.quantize(Decimal("0.01")),
-        total_net=total_net.quantize(Decimal("0.01")),
-        avg_savings_rate=avg_savings_rate,
-        months=months,
-    )
+    return await reporting.annual_report(session, year=year, account_id=account_id)

--- a/api/my_private_finances/api/routes/net_worth.py
+++ b/api/my_private_finances/api/routes/net_worth.py
@@ -5,56 +5,22 @@ Computes monthly account balances as:
                           where booking_date >= opening_balance_date
                           and booking_date <= month_end)
 
-Only accounts with opening_balance set are included.
+Only accounts with opening_balance set are included. The aggregation lives in
+``services.reporting.net_worth_report``.
 """
 
 from __future__ import annotations
 
-from datetime import date, timedelta
-from decimal import Decimal
-from typing import Annotated, Any, cast
+from typing import Annotated
 
 from fastapi import APIRouter
 from fastapi.params import Query
-from sqlalchemy import select
 
 from my_private_finances.deps import SessionDep
-from my_private_finances.models import Account, Transaction
-from my_private_finances.schemas import (
-    AccountBalancePoint,
-    AccountNetWorthSummary,
-    NetWorthPoint,
-    NetWorthReport,
-)
-from my_private_finances.utils.money import money_from_db
+from my_private_finances.schemas import NetWorthReport
+from my_private_finances.services import reporting
 
 router = APIRouter(prefix="/reports", tags=["reports"])
-
-
-def _month_end(year: int, month: int) -> date:
-    """Return the last day of the given month."""
-    if month == 12:
-        return date(year + 1, 1, 1) - timedelta(days=1)
-    return date(year, month + 1, 1) - timedelta(days=1)
-
-
-def _month_key(d: date) -> str:
-    return f"{d.year}-{d.month:02d}"
-
-
-def _target_months(months: int) -> list[date]:
-    """Return the last N month-end dates, oldest first."""
-    today = date.today()
-    results: list[date] = []
-    for i in range(months - 1, -1, -1):
-        # Go back i months from current month
-        year = today.year
-        month = today.month - i
-        while month <= 0:
-            month += 12
-            year -= 1
-        results.append(_month_end(year, month))
-    return results
 
 
 @router.get("/net-worth", response_model=NetWorthReport)
@@ -62,126 +28,4 @@ async def get_net_worth(
     session: SessionDep,
     months: Annotated[int, Query(ge=1, le=60)] = 12,
 ) -> NetWorthReport:
-    # Load accounts with opening_balance configured
-    res = await session.execute(
-        select(Account)  # type: ignore[arg-type]
-        .where(Account.opening_balance.is_not(None))  # type: ignore[union-attr]
-        .order_by(Account.id)  # type: ignore[arg-type]
-    )
-    accounts = list(res.scalars().all())
-
-    if not accounts:
-        return NetWorthReport(
-            currency="EUR",
-            current_total=Decimal("0"),
-            month_over_month_change=Decimal("0"),
-            accounts=[],
-            history=[],
-        )
-
-    tx = cast(Any, Transaction).__table__
-    target_month_ends = _target_months(months)
-    earliest_date = min(a.opening_balance_date for a in accounts)  # type: ignore[type-var]
-
-    # Fetch all relevant transactions for all accounts in one query
-    stmt = (
-        select(tx.c.account_id, tx.c.booking_date, tx.c.amount)
-        .where(
-            tx.c.account_id.in_([a.id for a in accounts])
-            & (tx.c.booking_date >= earliest_date)
-            & (tx.c.is_transfer == False)  # noqa: E712
-        )
-        .order_by(tx.c.booking_date)
-    )
-    tx_rows = (await session.execute(stmt)).all()
-
-    # Group transactions by account_id
-    tx_by_account: dict[int, list[tuple[date, Decimal]]] = {
-        a.id: [] for a in accounts if a.id is not None
-    }  # type: ignore[misc]
-    for row in tx_rows:
-        tx_by_account[row.account_id].append(
-            (row.booking_date, money_from_db(row.amount))
-        )
-
-    # Build monthly balance series per account
-    # balance_at[account_id][month_end_date] = Decimal
-    balance_series: dict[int, dict[date, Decimal]] = {}
-
-    for acc in accounts:
-        assert acc.id is not None
-        assert acc.opening_balance is not None
-        assert acc.opening_balance_date is not None
-
-        txs = tx_by_account[acc.id]
-        balances: dict[date, Decimal] = {}
-
-        for month_end in target_month_ends:
-            # Only include transactions from opening_balance_date up to month_end
-            total = sum(
-                (amt for d, amt in txs if acc.opening_balance_date <= d <= month_end),
-                Decimal("0"),
-            )
-            balances[month_end] = acc.opening_balance + total
-
-        balance_series[acc.id] = balances
-
-    # Build history (monthly aggregated net worth)
-    history: list[NetWorthPoint] = []
-    for month_end in target_month_ends:
-        by_account: list[AccountBalancePoint] = []
-        total = Decimal("0")
-        for acc in accounts:
-            assert acc.id is not None
-            bal = balance_series[acc.id].get(month_end, Decimal("0"))
-            # Only include if month_end >= opening_balance_date
-            if (
-                acc.opening_balance_date is not None
-                and month_end >= acc.opening_balance_date
-            ):
-                by_account.append(AccountBalancePoint(account_id=acc.id, balance=bal))
-                total += bal
-        history.append(
-            NetWorthPoint(
-                month=_month_key(month_end), total=total, by_account=by_account
-            )
-        )
-
-    # Current totals (last month-end)
-    current_total = history[-1].total if history else Decimal("0")
-    prev_total = history[-2].total if len(history) >= 2 else Decimal("0")
-    mom_change = current_total - prev_total
-
-    # Per-account summaries
-    account_summaries: list[AccountNetWorthSummary] = []
-    for acc in accounts:
-        assert acc.id is not None
-        assert acc.opening_balance is not None
-        assert acc.opening_balance_date is not None
-        current_bal = balance_series[acc.id].get(
-            target_month_ends[-1], acc.opening_balance
-        )
-        prev_bal = (
-            balance_series[acc.id].get(target_month_ends[-2], acc.opening_balance)
-            if len(target_month_ends) >= 2
-            else acc.opening_balance
-        )
-        account_summaries.append(
-            AccountNetWorthSummary(
-                account_id=acc.id,
-                account_name=acc.name,
-                currency=acc.currency,
-                opening_balance=acc.opening_balance,
-                opening_balance_date=acc.opening_balance_date,
-                current_balance=current_bal,
-                month_over_month_change=current_bal - prev_bal,
-            )
-        )
-
-    return NetWorthReport(
-        currency=accounts[0].currency if accounts else "EUR",
-        current_total=current_total,
-        month_over_month_change=mom_change,
-        accounts=account_summaries,
-        history=history,
-    )
+    return await reporting.net_worth_report(session, months=months)

--- a/api/my_private_finances/api/routes/reports.py
+++ b/api/my_private_finances/api/routes/reports.py
@@ -1,55 +1,19 @@
 from __future__ import annotations
 
-from datetime import date
-from decimal import Decimal
-from typing import Annotated, Any, Optional, cast
+from typing import Annotated, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi.params import Query
-from sqlalchemy import case, func, literal, select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from my_private_finances.deps import SessionDep
-from my_private_finances.models import Account, Budget, Category, Transaction
 from my_private_finances.schemas import (
     BudgetComparison,
-    CategoryTotal,
-    CostTypeBreakdown,
     FixedVsVariableReport,
     MonthlyReport,
-    PayeeTotal,
-    TopSpending,
 )
-from my_private_finances.utils.money import money_from_db
+from my_private_finances.services import reporting
 
 router = APIRouter(prefix="/reports", tags=["reports"])
-
-
-def _parse_month(value: str) -> tuple[date, date]:
-    try:
-        year_str, month_str = value.split("-")
-        year = int(year_str)
-        month = int(month_str)
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail="month must be in YYYY-MM") from e
-
-    if month < 1 or month > 12:
-        raise HTTPException(status_code=422, detail="month must be in [1-12]")
-
-    start = date(year, month, 1)
-    end = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
-    return start, end
-
-
-async def _resolve_currency(session: AsyncSession, account_id: Optional[int]) -> str:
-    """Return currency for a single account, or 'EUR' when aggregating all accounts."""
-    if account_id is None:
-        return "EUR"
-    res = await session.execute(select(Account).where(Account.id == account_id))  # type: ignore[arg-type]
-    acc = res.scalar_one_or_none()
-    if acc is None:
-        raise HTTPException(status_code=404, detail="Account not found")
-    return acc.currency
 
 
 @router.get("/monthly", response_model=MonthlyReport)
@@ -58,115 +22,7 @@ async def get_monthly_report(
     session: SessionDep,
     account_id: Annotated[Optional[int], Query(ge=1)] = None,
 ) -> MonthlyReport:
-    start, end = _parse_month(month)
-    currency = await _resolve_currency(session, account_id)
-
-    tx = cast(Any, Transaction).__table__
-
-    date_filter = (tx.c.booking_date >= start) & (tx.c.booking_date < end)
-    transfer_filter = tx.c.is_transfer == False  # noqa: E712
-    if account_id is not None:
-        base_filter = (tx.c.account_id == account_id) & date_filter & transfer_filter
-    else:
-        base_filter = date_filter & transfer_filter
-
-    stmt_totals = select(
-        func.count(literal(1)).label("tx_count"),
-        func.coalesce(func.sum(tx.c.amount), 0).label("net_total"),
-        func.coalesce(
-            func.sum(case((tx.c.amount > 0, tx.c.amount), else_=0)),
-            0,
-        ).label("income_total"),
-        func.coalesce(
-            func.sum(case((tx.c.amount < 0, tx.c.amount), else_=0)),
-            0,
-        ).label("expense_total"),
-    ).where(base_filter)
-
-    totals_row = (await session.execute(stmt_totals)).one()
-    tx_count = int(totals_row.tx_count)
-    net_total = money_from_db(totals_row.net_total)
-    income_total = money_from_db(totals_row.income_total)
-    expense_total = money_from_db(totals_row.expense_total)
-
-    stmt_payees = (
-        select(
-            tx.c.payee,
-            func.coalesce(func.sum(tx.c.amount), 0).label("total"),
-        )
-        .where(base_filter)
-        .where(tx.c.amount < 0)
-        .group_by(tx.c.payee)
-        .order_by(func.sum(tx.c.amount).asc())
-        .limit(15)
-    )
-
-    payees_rows = (await session.execute(stmt_payees)).all()
-    payees = [
-        PayeeTotal(payee=r.payee, total=money_from_db(r.total)) for r in payees_rows
-    ]
-
-    cat = cast(Any, Category).__table__
-    stmt_categories = (
-        select(
-            cat.c.name.label("category_name"),
-            func.coalesce(func.sum(tx.c.amount), 0).label("total"),
-        )
-        .select_from(tx.outerjoin(cat, tx.c.category_id == cat.c.id))
-        .where(base_filter)
-        .where(tx.c.amount < 0)
-        .group_by(tx.c.category_id)
-        .order_by(func.sum(tx.c.amount).asc())
-    )
-
-    cat_rows = (await session.execute(stmt_categories)).all()
-    categories = [
-        CategoryTotal(
-            category_name=r.category_name,
-            total=money_from_db(r.total),
-        )
-        for r in cat_rows
-    ]
-
-    stmt_top_spendings = (
-        select(
-            tx.c.booking_date,
-            tx.c.payee,
-            tx.c.purpose,
-            tx.c.amount,
-            cat.c.name.label("category_name"),
-        )
-        .select_from(tx.outerjoin(cat, tx.c.category_id == cat.c.id))
-        .where(base_filter)
-        .where(tx.c.amount < 0)
-        .order_by(tx.c.amount.asc())
-        .limit(10)
-    )
-
-    spending_rows = (await session.execute(stmt_top_spendings)).all()
-    spendings = [
-        TopSpending(
-            booking_date=r.booking_date,
-            payee=r.payee,
-            purpose=r.purpose,
-            amount=money_from_db(r.amount),
-            category_name=r.category_name,
-        )
-        for r in spending_rows
-    ]
-
-    return MonthlyReport(
-        account_id=account_id,
-        month=month,
-        currency=currency,
-        transactions_count=tx_count,
-        income_total=income_total,
-        expense_total=expense_total,
-        net_total=net_total,
-        top_payees=payees,
-        category_breakdown=categories,
-        top_spendings=spendings,
-    )
+    return await reporting.monthly_report(session, month=month, account_id=account_id)
 
 
 @router.get("/budget-vs-actual", response_model=list[BudgetComparison])
@@ -175,69 +31,7 @@ async def get_budget_vs_actual(
     session: SessionDep,
     account_id: Annotated[Optional[int], Query(ge=1)] = None,
 ) -> list[BudgetComparison]:
-    start, end = _parse_month(month)
-
-    if account_id is not None:
-        res_acc = await session.execute(select(Account).where(Account.id == account_id))  # type: ignore[arg-type]
-        if res_acc.scalar_one_or_none() is None:
-            raise HTTPException(status_code=404, detail="Account not found")
-
-    tx = cast(Any, Transaction).__table__
-    cat = cast(Any, Category).__table__
-    budget_t = cast(Any, Budget).__table__
-
-    # Get all budgets with category names
-    stmt_budgets = (
-        select(
-            budget_t.c.category_id,
-            cat.c.name.label("category_name"),
-            budget_t.c.amount.label("budgeted"),
-        )
-        .join(cat, budget_t.c.category_id == cat.c.id)
-        .order_by(cat.c.name)
-    )
-    budget_rows = (await session.execute(stmt_budgets)).all()
-
-    if not budget_rows:
-        return []
-
-    # Get actual spending per category for this month
-    transfer_filter = tx.c.is_transfer == False  # noqa: E712
-    date_filter = (
-        (tx.c.booking_date >= start) & (tx.c.booking_date < end) & (tx.c.amount < 0)
-    )
-    if account_id is not None:
-        base_filter = (tx.c.account_id == account_id) & date_filter & transfer_filter
-    else:
-        base_filter = date_filter & transfer_filter
-
-    stmt_actuals = (
-        select(
-            tx.c.category_id,
-            func.coalesce(func.sum(tx.c.amount), 0).label("actual"),
-        )
-        .where(base_filter)
-        .group_by(tx.c.category_id)
-    )
-    actual_rows = (await session.execute(stmt_actuals)).all()
-    actuals = {r.category_id: money_from_db(r.actual) for r in actual_rows}
-
-    result = []
-    for row in budget_rows:
-        raw_actual = actuals.get(row.category_id, Decimal("0"))
-        actual = abs(raw_actual)
-        budgeted = money_from_db(row.budgeted)
-        result.append(
-            BudgetComparison(
-                category_id=row.category_id,
-                category_name=row.category_name,
-                budgeted=budgeted,
-                actual=actual,
-                remaining=budgeted - actual,
-            )
-        )
-
-    return result
+    return await reporting.budget_vs_actual(session, month=month, account_id=account_id)
 
 
 @router.get("/fixed-vs-variable", response_model=FixedVsVariableReport)
@@ -246,53 +40,6 @@ async def get_fixed_vs_variable(
     session: SessionDep,
     account_id: Annotated[Optional[int], Query(ge=1)] = None,
 ) -> FixedVsVariableReport:
-    start, end = _parse_month(month)
-    currency = await _resolve_currency(session, account_id)
-
-    tx = cast(Any, Transaction).__table__
-    cat = cast(Any, Category).__table__
-
-    transfer_filter = tx.c.is_transfer == False  # noqa: E712
-    date_filter = (
-        (tx.c.booking_date >= start) & (tx.c.booking_date < end) & (tx.c.amount < 0)
-    )
-    if account_id is not None:
-        base_filter = (tx.c.account_id == account_id) & date_filter & transfer_filter
-    else:
-        base_filter = date_filter & transfer_filter
-
-    stmt = (
-        select(
-            cat.c.cost_type,
-            func.coalesce(func.sum(tx.c.amount), 0).label("total"),
-            func.count(func.distinct(cat.c.id)).label("category_count"),
-        )
-        .select_from(tx.outerjoin(cat, tx.c.category_id == cat.c.id))
-        .where(base_filter)
-        .group_by(cat.c.cost_type)
-    )
-
-    rows = (await session.execute(stmt)).all()
-
-    totals: dict[str | None, Decimal] = {}
-    breakdown: list[CostTypeBreakdown] = []
-    for r in rows:
-        total = abs(money_from_db(r.total))
-        totals[r.cost_type] = total
-        breakdown.append(
-            CostTypeBreakdown(
-                cost_type=r.cost_type,
-                total=total,
-                category_count=int(r.category_count),
-            )
-        )
-
-    return FixedVsVariableReport(
-        account_id=account_id,
-        month=month,
-        currency=currency,
-        fixed_total=totals.get("fixed", Decimal("0")),
-        variable_total=totals.get("variable", Decimal("0")),
-        unclassified_total=totals.get(None, Decimal("0")),
-        breakdown=breakdown,
+    return await reporting.fixed_vs_variable(
+        session, month=month, account_id=account_id
     )

--- a/api/my_private_finances/api/routes/trends.py
+++ b/api/my_private_finances/api/routes/trends.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
-import calendar
-from datetime import date
-from decimal import Decimal
-from typing import Annotated, Any, Optional, cast
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, Query
-from sqlalchemy import select
 
-from my_private_finances.api.routes.reports import _parse_month, _resolve_currency
 from my_private_finances.deps import SessionDep
-from my_private_finances.models import Category, Transaction
-from my_private_finances.schemas import CategoryTrendItem, SpendingTrendReport
-from my_private_finances.utils.money import money_from_db
+from my_private_finances.schemas import SpendingTrendReport
+from my_private_finances.services import reporting
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
@@ -24,132 +18,9 @@ async def get_spending_trend(
     lookback_months: Annotated[int, Query(ge=1, le=24)] = 3,
     account_id: Annotated[Optional[int], Query(ge=1)] = None,
 ) -> SpendingTrendReport:
-    month_start, month_end = _parse_month(month)
-    currency = await _resolve_currency(session, account_id)
-
-    # Compute lookback window: N complete months immediately before month_start
-    lookback_end = month_start  # exclusive
-    # Go back N months
-    lb_year = month_start.year
-    lb_month = month_start.month - lookback_months
-    while lb_month <= 0:
-        lb_month += 12
-        lb_year -= 1
-    lookback_start = date(lb_year, lb_month, 1)
-
-    tx = cast(Any, Transaction).__table__
-    cat = cast(Any, Category).__table__
-
-    # Fetch all expense rows in [lookback_start, month_end)
-    transfer_filter = tx.c.is_transfer == False  # noqa: E712
-    expense_filter = tx.c.amount < 0
-    date_filter = (tx.c.booking_date >= lookback_start) & (
-        tx.c.booking_date < month_end
-    )
-
-    if account_id is not None:
-        base_filter = (
-            (tx.c.account_id == account_id)
-            & date_filter
-            & transfer_filter
-            & expense_filter
-        )
-    else:
-        base_filter = date_filter & transfer_filter & expense_filter
-
-    stmt = (
-        select(
-            tx.c.booking_date,
-            tx.c.category_id,
-            cat.c.name.label("category_name"),
-            tx.c.amount,
-        )
-        .select_from(tx.outerjoin(cat, tx.c.category_id == cat.c.id))
-        .where(base_filter)
-    )
-
-    rows = (await session.execute(stmt)).all()
-
-    # Separate into lookback months vs current month
-    # Aggregate: per-category, per-month totals for lookback; per-category total for current
-    lookback_by_cat: dict[
-        int | None, dict[str, Decimal]
-    ] = {}  # cat_id -> month_str -> total
-    current_by_cat: dict[int | None, Decimal] = {}
-    cat_names: dict[int | None, str | None] = {}
-
-    for row in rows:
-        bdate: date = row.booking_date
-        cat_id: int | None = row.category_id
-        cat_name: str | None = row.category_name
-        amount = money_from_db(row.amount)
-
-        cat_names[cat_id] = cat_name
-
-        if bdate < lookback_end:
-            # lookback month
-            month_str = f"{bdate.year}-{bdate.month:02d}"
-            if cat_id not in lookback_by_cat:
-                lookback_by_cat[cat_id] = {}
-            lookback_by_cat[cat_id][month_str] = (
-                lookback_by_cat[cat_id].get(month_str, Decimal("0")) + amount
-            )
-        else:
-            # current month
-            current_by_cat[cat_id] = current_by_cat.get(cat_id, Decimal("0")) + amount
-
-    # Gather all category IDs
-    all_cat_ids = set(lookback_by_cat.keys()) | set(current_by_cat.keys())
-
-    # Compute projection factor
-    today = date.today()
-    days_in_month = calendar.monthrange(month_start.year, month_start.month)[1]
-    if today >= month_end:
-        # month is complete
-        days_elapsed = days_in_month
-    else:
-        days_elapsed = max(today.day, 1)
-    projection_factor = Decimal(days_in_month) / Decimal(days_elapsed)
-
-    categories: list[CategoryTrendItem] = []
-    for cat_id in all_cat_ids:
-        name = cat_names.get(cat_id)
-
-        # avg_monthly: sum of monthly totals in lookback / N (as positive)
-        monthly_totals = lookback_by_cat.get(cat_id, {})
-        lookback_sum = sum(monthly_totals.values(), Decimal("0"))
-        avg_monthly = abs(lookback_sum) / Decimal(lookback_months)
-
-        # current_month: actual this month (positive)
-        raw_current = current_by_cat.get(cat_id, Decimal("0"))
-        current_month = abs(raw_current)
-
-        # projected: current * factor
-        projected = (current_month * projection_factor).quantize(Decimal("0.01"))
-
-        categories.append(
-            CategoryTrendItem(
-                category_name=name,
-                avg_monthly=avg_monthly.quantize(Decimal("0.01")),
-                current_month=current_month.quantize(Decimal("0.01")),
-                projected=projected,
-            )
-        )
-
-    # Sort by avg_monthly descending (biggest spenders first)
-    categories.sort(key=lambda c: c.avg_monthly, reverse=True)
-
-    total_avg = sum((c.avg_monthly for c in categories), Decimal("0"))
-    total_current = sum((c.current_month for c in categories), Decimal("0"))
-    total_projected = sum((c.projected for c in categories), Decimal("0"))
-
-    return SpendingTrendReport(
-        account_id=account_id,
+    return await reporting.spending_trend(
+        session,
         month=month,
         lookback_months=lookback_months,
-        currency=currency,
-        total_avg_monthly=total_avg.quantize(Decimal("0.01")),
-        total_current_month=total_current.quantize(Decimal("0.01")),
-        total_projected=total_projected.quantize(Decimal("0.01")),
-        categories=categories,
+        account_id=account_id,
     )

--- a/api/my_private_finances/main.py
+++ b/api/my_private_finances/main.py
@@ -6,7 +6,8 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from my_private_finances.api.router import api_router
@@ -14,6 +15,7 @@ from my_private_finances.config import Settings, get_settings
 from my_private_finances.db import create_engine, create_session_factory
 from my_private_finances.logging_config import setup_logging
 from my_private_finances.models.watch_folder_config import WatchSettings
+from my_private_finances.services.reporting import ReportError
 from my_private_finances.services.watch_folder import watch_folder_task
 
 setup_logging()
@@ -62,6 +64,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
 
     app = FastAPI(title="My Private Finances", lifespan=_lifespan)
+
+    @app.exception_handler(ReportError)
+    async def _report_error_handler(request: Request, exc: ReportError) -> JSONResponse:
+        return JSONResponse(status_code=exc.status_code, content={"detail": str(exc)})
 
     engine: AsyncEngine = create_engine(settings.resolved_database_url)
     session_factory: async_sessionmaker[AsyncSession] = create_session_factory(engine)

--- a/api/my_private_finances/services/reporting.py
+++ b/api/my_private_finances/services/reporting.py
@@ -1,0 +1,668 @@
+"""Reporting aggregations (review finding A1 / issue #104).
+
+All the monthly / annual / trend / net-worth SQL used to live inline in the
+route handlers. It now lives here as plain ``async`` functions that take an
+``AsyncSession`` and return the typed response schemas; the routes are thin
+adapters. Shared filter-building (the ``is_transfer`` guard, the month window,
+the account scope) is defined once in :func:`non_transfer_filter`.
+"""
+
+from __future__ import annotations
+
+import calendar
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any, Optional, cast
+
+from sqlalchemy import ColumnElement, and_, case, func, literal, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from my_private_finances.models import Account, Budget, Category, Transaction
+from my_private_finances.schemas import (
+    AccountBalancePoint,
+    AccountNetWorthSummary,
+    AnnualReport,
+    BudgetComparison,
+    CategoryTotal,
+    CategoryTrendItem,
+    CostTypeBreakdown,
+    FixedVsVariableReport,
+    MonthlyReport,
+    MonthSummary,
+    NetWorthPoint,
+    NetWorthReport,
+    PayeeTotal,
+    SpendingTrendReport,
+    TopSpending,
+)
+from my_private_finances.utils.money import money_from_db
+
+_ZERO = Decimal("0")
+_CENTS = Decimal("0.01")
+_HUNDRED = Decimal("100")
+
+
+class ReportError(Exception):
+    """Base class for reporting input errors; carries an HTTP status code."""
+
+    status_code = 400
+
+
+class InvalidMonth(ReportError):
+    status_code = 422
+
+
+class AccountNotFound(ReportError):
+    status_code = 404
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
+
+_TX = cast(Any, Transaction).__table__
+_CAT = cast(Any, Category).__table__
+_BUDGET = cast(Any, Budget).__table__
+
+
+def parse_month(value: str) -> tuple[date, date]:
+    """Parse ``"YYYY-MM"`` into a ``[start, end)`` half-open date range."""
+    try:
+        year_str, month_str = value.split("-")
+        year = int(year_str)
+        month = int(month_str)
+    except ValueError as e:
+        raise InvalidMonth("month must be in YYYY-MM") from e
+
+    if month < 1 or month > 12:
+        raise InvalidMonth("month must be in [1-12]")
+
+    start = date(year, month, 1)
+    end = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
+    return start, end
+
+
+async def resolve_currency(session: AsyncSession, account_id: Optional[int]) -> str:
+    """Currency for a single account, or ``"EUR"`` when aggregating all accounts."""
+    if account_id is None:
+        return "EUR"
+    res = await session.execute(select(Account).where(Account.id == account_id))  # type: ignore[arg-type]
+    acc = res.scalar_one_or_none()
+    if acc is None:
+        raise AccountNotFound("Account not found")
+    return acc.currency
+
+
+async def _require_account(session: AsyncSession, account_id: Optional[int]) -> None:
+    if account_id is None:
+        return
+    res = await session.execute(select(Account).where(Account.id == account_id))  # type: ignore[arg-type]
+    if res.scalar_one_or_none() is None:
+        raise AccountNotFound("Account not found")
+
+
+def non_transfer_filter(
+    *,
+    account_id: Optional[int],
+    start: date,
+    end: date,
+    expenses_only: bool = False,
+) -> ColumnElement[bool]:
+    """The filter every report shares: non-transfer rows in ``[start, end)``,
+    optionally scoped to one account and/or restricted to expenses."""
+    conditions: list[Any] = [
+        _TX.c.booking_date >= start,
+        _TX.c.booking_date < end,
+        _TX.c.is_transfer == False,  # noqa: E712
+    ]
+    if account_id is not None:
+        conditions.append(_TX.c.account_id == account_id)
+    if expenses_only:
+        conditions.append(_TX.c.amount < 0)
+    return and_(*conditions)
+
+
+# --------------------------------------------------------------------------- #
+# Monthly report
+# --------------------------------------------------------------------------- #
+
+
+async def monthly_report(
+    session: AsyncSession,
+    *,
+    month: str,
+    account_id: Optional[int] = None,
+) -> MonthlyReport:
+    start, end = parse_month(month)
+    currency = await resolve_currency(session, account_id)
+
+    base_filter = non_transfer_filter(account_id=account_id, start=start, end=end)
+    expense_filter = and_(base_filter, _TX.c.amount < 0)
+
+    totals_row = (
+        await session.execute(
+            select(
+                func.count(literal(1)).label("tx_count"),
+                func.coalesce(func.sum(_TX.c.amount), 0).label("net_total"),
+                func.coalesce(
+                    func.sum(case((_TX.c.amount > 0, _TX.c.amount), else_=0)), 0
+                ).label("income_total"),
+                func.coalesce(
+                    func.sum(case((_TX.c.amount < 0, _TX.c.amount), else_=0)), 0
+                ).label("expense_total"),
+            ).where(base_filter)
+        )
+    ).one()
+
+    payees_rows = (
+        await session.execute(
+            select(
+                _TX.c.payee,
+                func.coalesce(func.sum(_TX.c.amount), 0).label("total"),
+            )
+            .where(expense_filter)
+            .group_by(_TX.c.payee)
+            .order_by(func.sum(_TX.c.amount).asc())
+            .limit(15)
+        )
+    ).all()
+
+    cat_rows = (
+        await session.execute(
+            select(
+                _CAT.c.name.label("category_name"),
+                func.coalesce(func.sum(_TX.c.amount), 0).label("total"),
+            )
+            .select_from(_TX.outerjoin(_CAT, _TX.c.category_id == _CAT.c.id))
+            .where(expense_filter)
+            .group_by(_TX.c.category_id)
+            .order_by(func.sum(_TX.c.amount).asc())
+        )
+    ).all()
+
+    spending_rows = (
+        await session.execute(
+            select(
+                _TX.c.booking_date,
+                _TX.c.payee,
+                _TX.c.purpose,
+                _TX.c.amount,
+                _CAT.c.name.label("category_name"),
+            )
+            .select_from(_TX.outerjoin(_CAT, _TX.c.category_id == _CAT.c.id))
+            .where(expense_filter)
+            .order_by(_TX.c.amount.asc())
+            .limit(10)
+        )
+    ).all()
+
+    return MonthlyReport(
+        account_id=account_id,
+        month=month,
+        currency=currency,
+        transactions_count=int(totals_row.tx_count),
+        income_total=money_from_db(totals_row.income_total),
+        expense_total=money_from_db(totals_row.expense_total),
+        net_total=money_from_db(totals_row.net_total),
+        top_payees=[
+            PayeeTotal(payee=r.payee, total=money_from_db(r.total)) for r in payees_rows
+        ],
+        category_breakdown=[
+            CategoryTotal(category_name=r.category_name, total=money_from_db(r.total))
+            for r in cat_rows
+        ],
+        top_spendings=[
+            TopSpending(
+                booking_date=r.booking_date,
+                payee=r.payee,
+                purpose=r.purpose,
+                amount=money_from_db(r.amount),
+                category_name=r.category_name,
+            )
+            for r in spending_rows
+        ],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Budget vs actual
+# --------------------------------------------------------------------------- #
+
+
+async def budget_vs_actual(
+    session: AsyncSession,
+    *,
+    month: str,
+    account_id: Optional[int] = None,
+) -> list[BudgetComparison]:
+    start, end = parse_month(month)
+    await _require_account(session, account_id)
+
+    budget_rows = (
+        await session.execute(
+            select(
+                _BUDGET.c.category_id,
+                _CAT.c.name.label("category_name"),
+                _BUDGET.c.amount.label("budgeted"),
+            )
+            .join(_CAT, _BUDGET.c.category_id == _CAT.c.id)
+            .order_by(_CAT.c.name)
+        )
+    ).all()
+    if not budget_rows:
+        return []
+
+    actual_rows = (
+        await session.execute(
+            select(
+                _TX.c.category_id,
+                func.coalesce(func.sum(_TX.c.amount), 0).label("actual"),
+            )
+            .where(
+                non_transfer_filter(
+                    account_id=account_id, start=start, end=end, expenses_only=True
+                )
+            )
+            .group_by(_TX.c.category_id)
+        )
+    ).all()
+    actuals = {r.category_id: money_from_db(r.actual) for r in actual_rows}
+
+    result: list[BudgetComparison] = []
+    for row in budget_rows:
+        actual = abs(actuals.get(row.category_id, _ZERO))
+        budgeted = money_from_db(row.budgeted)
+        result.append(
+            BudgetComparison(
+                category_id=row.category_id,
+                category_name=row.category_name,
+                budgeted=budgeted,
+                actual=actual,
+                remaining=budgeted - actual,
+            )
+        )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Fixed vs variable
+# --------------------------------------------------------------------------- #
+
+
+async def fixed_vs_variable(
+    session: AsyncSession,
+    *,
+    month: str,
+    account_id: Optional[int] = None,
+) -> FixedVsVariableReport:
+    start, end = parse_month(month)
+    currency = await resolve_currency(session, account_id)
+
+    rows = (
+        await session.execute(
+            select(
+                _CAT.c.cost_type,
+                func.coalesce(func.sum(_TX.c.amount), 0).label("total"),
+                func.count(func.distinct(_CAT.c.id)).label("category_count"),
+            )
+            .select_from(_TX.outerjoin(_CAT, _TX.c.category_id == _CAT.c.id))
+            .where(
+                non_transfer_filter(
+                    account_id=account_id, start=start, end=end, expenses_only=True
+                )
+            )
+            .group_by(_CAT.c.cost_type)
+        )
+    ).all()
+
+    totals: dict[str | None, Decimal] = {}
+    breakdown: list[CostTypeBreakdown] = []
+    for r in rows:
+        total = abs(money_from_db(r.total))
+        totals[r.cost_type] = total
+        breakdown.append(
+            CostTypeBreakdown(
+                cost_type=r.cost_type,
+                total=total,
+                category_count=int(r.category_count),
+            )
+        )
+
+    return FixedVsVariableReport(
+        account_id=account_id,
+        month=month,
+        currency=currency,
+        fixed_total=totals.get("fixed", _ZERO),
+        variable_total=totals.get("variable", _ZERO),
+        unclassified_total=totals.get(None, _ZERO),
+        breakdown=breakdown,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Spending trend
+# --------------------------------------------------------------------------- #
+
+
+async def spending_trend(
+    session: AsyncSession,
+    *,
+    month: str,
+    lookback_months: int = 3,
+    account_id: Optional[int] = None,
+) -> SpendingTrendReport:
+    month_start, month_end = parse_month(month)
+    currency = await resolve_currency(session, account_id)
+
+    lb_year = month_start.year
+    lb_month = month_start.month - lookback_months
+    while lb_month <= 0:
+        lb_month += 12
+        lb_year -= 1
+    lookback_start = date(lb_year, lb_month, 1)
+
+    rows = (
+        await session.execute(
+            select(
+                _TX.c.booking_date,
+                _TX.c.category_id,
+                _CAT.c.name.label("category_name"),
+                _TX.c.amount,
+            )
+            .select_from(_TX.outerjoin(_CAT, _TX.c.category_id == _CAT.c.id))
+            .where(
+                non_transfer_filter(
+                    account_id=account_id,
+                    start=lookback_start,
+                    end=month_end,
+                    expenses_only=True,
+                )
+            )
+        )
+    ).all()
+
+    lookback_by_cat: dict[int | None, dict[str, Decimal]] = {}
+    current_by_cat: dict[int | None, Decimal] = {}
+    cat_names: dict[int | None, str | None] = {}
+
+    for row in rows:
+        bdate: date = row.booking_date
+        cat_id: int | None = row.category_id
+        amount = money_from_db(row.amount)
+        cat_names[cat_id] = row.category_name
+
+        if bdate < month_start:
+            month_str = f"{bdate.year}-{bdate.month:02d}"
+            per_month = lookback_by_cat.setdefault(cat_id, {})
+            per_month[month_str] = per_month.get(month_str, _ZERO) + amount
+        else:
+            current_by_cat[cat_id] = current_by_cat.get(cat_id, _ZERO) + amount
+
+    today = date.today()
+    days_in_month = calendar.monthrange(month_start.year, month_start.month)[1]
+    days_elapsed = days_in_month if today >= month_end else max(today.day, 1)
+    projection_factor = Decimal(days_in_month) / Decimal(days_elapsed)
+
+    categories: list[CategoryTrendItem] = []
+    for cat_id in set(lookback_by_cat) | set(current_by_cat):
+        lookback_sum = sum(lookback_by_cat.get(cat_id, {}).values(), _ZERO)
+        avg_monthly = abs(lookback_sum) / Decimal(lookback_months)
+        current_month = abs(current_by_cat.get(cat_id, _ZERO))
+        projected = (current_month * projection_factor).quantize(_CENTS)
+        categories.append(
+            CategoryTrendItem(
+                category_name=cat_names.get(cat_id),
+                avg_monthly=avg_monthly.quantize(_CENTS),
+                current_month=current_month.quantize(_CENTS),
+                projected=projected,
+            )
+        )
+
+    categories.sort(key=lambda c: c.avg_monthly, reverse=True)
+
+    return SpendingTrendReport(
+        account_id=account_id,
+        month=month,
+        lookback_months=lookback_months,
+        currency=currency,
+        total_avg_monthly=sum((c.avg_monthly for c in categories), _ZERO).quantize(
+            _CENTS
+        ),
+        total_current_month=sum((c.current_month for c in categories), _ZERO).quantize(
+            _CENTS
+        ),
+        total_projected=sum((c.projected for c in categories), _ZERO).quantize(_CENTS),
+        categories=categories,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Annual report
+# --------------------------------------------------------------------------- #
+
+
+async def annual_report(
+    session: AsyncSession,
+    *,
+    year: Optional[int] = None,
+    account_id: Optional[int] = None,
+) -> AnnualReport:
+    if year is None:
+        year = date.today().year
+
+    year_start = date(year, 1, 1)
+    year_end = date(year + 1, 1, 1)
+    currency = await resolve_currency(session, account_id)
+
+    rows = (
+        await session.execute(
+            select(_TX.c.booking_date, _TX.c.amount).where(
+                non_transfer_filter(
+                    account_id=account_id, start=year_start, end=year_end
+                )
+            )
+        )
+    ).all()
+
+    income_by_month: dict[str, Decimal] = {}
+    expenses_by_month: dict[str, Decimal] = {}
+    for row in rows:
+        bdate: date = row.booking_date
+        month_str = f"{bdate.year}-{bdate.month:02d}"
+        amount = money_from_db(row.amount)
+        if amount > _ZERO:
+            income_by_month[month_str] = income_by_month.get(month_str, _ZERO) + amount
+        else:
+            expenses_by_month[month_str] = expenses_by_month.get(
+                month_str, _ZERO
+            ) + abs(amount)
+
+    months: list[MonthSummary] = []
+    for m in range(1, 13):
+        month_str = f"{year}-{m:02d}"
+        income = income_by_month.get(month_str, _ZERO)
+        expenses = expenses_by_month.get(month_str, _ZERO)
+        net = income - expenses
+        savings_rate = (
+            (net / income * _HUNDRED).quantize(_CENTS)
+            if income > _ZERO
+            else _ZERO.quantize(_CENTS)
+        )
+        months.append(
+            MonthSummary(
+                month=month_str,
+                income=income.quantize(_CENTS),
+                expenses=expenses.quantize(_CENTS),
+                net=net.quantize(_CENTS),
+                savings_rate=savings_rate,
+            )
+        )
+
+    total_income = sum((m.income for m in months), _ZERO)
+    total_expenses = sum((m.expenses for m in months), _ZERO)
+    total_net = total_income - total_expenses
+
+    months_with_income = [m for m in months if m.income > _ZERO]
+    avg_savings_rate = (
+        (
+            sum((m.savings_rate for m in months_with_income), _ZERO)
+            / Decimal(len(months_with_income))
+        ).quantize(_CENTS)
+        if months_with_income
+        else _ZERO
+    )
+
+    return AnnualReport(
+        year=year,
+        account_id=account_id,
+        currency=currency,
+        total_income=total_income.quantize(_CENTS),
+        total_expenses=total_expenses.quantize(_CENTS),
+        total_net=total_net.quantize(_CENTS),
+        avg_savings_rate=avg_savings_rate,
+        months=months,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Net worth
+# --------------------------------------------------------------------------- #
+
+
+def _month_end(year: int, month: int) -> date:
+    if month == 12:
+        return date(year + 1, 1, 1) - timedelta(days=1)
+    return date(year, month + 1, 1) - timedelta(days=1)
+
+
+def _month_key(d: date) -> str:
+    return f"{d.year}-{d.month:02d}"
+
+
+def _target_months(months: int) -> list[date]:
+    """The last N month-end dates, oldest first."""
+    today = date.today()
+    results: list[date] = []
+    for i in range(months - 1, -1, -1):
+        year = today.year
+        month = today.month - i
+        while month <= 0:
+            month += 12
+            year -= 1
+        results.append(_month_end(year, month))
+    return results
+
+
+async def net_worth_report(
+    session: AsyncSession,
+    *,
+    months: int = 12,
+) -> NetWorthReport:
+    res = await session.execute(
+        select(Account)  # type: ignore[arg-type]
+        .where(Account.opening_balance.is_not(None))  # type: ignore[union-attr]
+        .order_by(Account.id)  # type: ignore[arg-type]
+    )
+    accounts = list(res.scalars().all())
+
+    if not accounts:
+        return NetWorthReport(
+            currency="EUR",
+            current_total=_ZERO,
+            month_over_month_change=_ZERO,
+            accounts=[],
+            history=[],
+        )
+
+    target_month_ends = _target_months(months)
+    earliest_date = min(a.opening_balance_date for a in accounts)  # type: ignore[type-var]
+
+    tx_rows = (
+        await session.execute(
+            select(_TX.c.account_id, _TX.c.booking_date, _TX.c.amount)
+            .where(
+                _TX.c.account_id.in_([a.id for a in accounts])
+                & (_TX.c.booking_date >= earliest_date)
+                & (_TX.c.is_transfer == False)  # noqa: E712
+            )
+            .order_by(_TX.c.booking_date)
+        )
+    ).all()
+
+    tx_by_account: dict[int, list[tuple[date, Decimal]]] = {
+        a.id: [] for a in accounts if a.id is not None
+    }
+    for row in tx_rows:
+        tx_by_account[row.account_id].append(
+            (row.booking_date, money_from_db(row.amount))
+        )
+
+    balance_series: dict[int, dict[date, Decimal]] = {}
+    for acc in accounts:
+        assert acc.id is not None
+        assert acc.opening_balance is not None
+        assert acc.opening_balance_date is not None
+        txs = tx_by_account[acc.id]
+        balances: dict[date, Decimal] = {}
+        for month_end in target_month_ends:
+            total = sum(
+                (amt for d, amt in txs if acc.opening_balance_date <= d <= month_end),
+                _ZERO,
+            )
+            balances[month_end] = acc.opening_balance + total
+        balance_series[acc.id] = balances
+
+    history: list[NetWorthPoint] = []
+    for month_end in target_month_ends:
+        by_account: list[AccountBalancePoint] = []
+        total = _ZERO
+        for acc in accounts:
+            assert acc.id is not None
+            bal = balance_series[acc.id].get(month_end, _ZERO)
+            if (
+                acc.opening_balance_date is not None
+                and month_end >= acc.opening_balance_date
+            ):
+                by_account.append(AccountBalancePoint(account_id=acc.id, balance=bal))
+                total += bal
+        history.append(
+            NetWorthPoint(
+                month=_month_key(month_end), total=total, by_account=by_account
+            )
+        )
+
+    current_total = history[-1].total if history else _ZERO
+    prev_total = history[-2].total if len(history) >= 2 else _ZERO
+
+    account_summaries: list[AccountNetWorthSummary] = []
+    for acc in accounts:
+        assert acc.id is not None
+        assert acc.opening_balance is not None
+        assert acc.opening_balance_date is not None
+        current_bal = balance_series[acc.id].get(
+            target_month_ends[-1], acc.opening_balance
+        )
+        prev_bal = (
+            balance_series[acc.id].get(target_month_ends[-2], acc.opening_balance)
+            if len(target_month_ends) >= 2
+            else acc.opening_balance
+        )
+        account_summaries.append(
+            AccountNetWorthSummary(
+                account_id=acc.id,
+                account_name=acc.name,
+                currency=acc.currency,
+                opening_balance=acc.opening_balance,
+                opening_balance_date=acc.opening_balance_date,
+                current_balance=current_bal,
+                month_over_month_change=current_bal - prev_bal,
+            )
+        )
+
+    return NetWorthReport(
+        currency=accounts[0].currency,
+        current_total=current_total,
+        month_over_month_change=current_total - prev_total,
+        accounts=account_summaries,
+        history=history,
+    )

--- a/api/tests/test_budget_vs_actual_direct.py
+++ b/api/tests/test_budget_vs_actual_direct.py
@@ -4,35 +4,37 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from my_private_finances.api.routes.reports import _parse_month, get_budget_vs_actual
 from my_private_finances.models import Account, Budget, Category, Transaction
+from my_private_finances.services.reporting import (
+    AccountNotFound,
+    InvalidMonth,
+    budget_vs_actual,
+    parse_month,
+)
 
 
 def test_parse_month_valid() -> None:
-    start, end = _parse_month("2026-05")
+    start, end = parse_month("2026-05")
     assert start == date(2026, 5, 1)
     assert end == date(2026, 6, 1)
 
 
 def test_parse_month_december() -> None:
-    start, end = _parse_month("2026-12")
+    start, end = parse_month("2026-12")
     assert start == date(2026, 12, 1)
     assert end == date(2027, 1, 1)
 
 
 def test_parse_month_invalid_format() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        _parse_month("bad")
-    assert exc_info.value.status_code == 422
+    with pytest.raises(InvalidMonth):
+        parse_month("bad")
 
 
 def test_parse_month_invalid_month_number() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        _parse_month("2026-13")
-    assert exc_info.value.status_code == 422
+    with pytest.raises(InvalidMonth):
+        parse_month("2026-13")
 
 
 @pytest.mark.asyncio
@@ -64,10 +66,10 @@ async def test_budget_vs_actual_direct(db_session: AsyncSession) -> None:
     db_session.add(tx)
     await db_session.commit()
 
-    result = await get_budget_vs_actual(
-        account_id=acc.id,
+    result = await budget_vs_actual(
+        db_session,
         month="2026-05",
-        session=db_session,  # type: ignore[arg-type]
+        account_id=acc.id,
     )
 
     assert len(result) == 1
@@ -79,8 +81,5 @@ async def test_budget_vs_actual_direct(db_session: AsyncSession) -> None:
 
 @pytest.mark.asyncio
 async def test_budget_vs_actual_account_not_found(db_session: AsyncSession) -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        await get_budget_vs_actual(
-            account_id=99999, month="2026-05", session=db_session
-        )
-    assert exc_info.value.status_code == 404
+    with pytest.raises(AccountNotFound):
+        await budget_vs_actual(db_session, month="2026-05", account_id=99999)

--- a/api/tests/test_fixed_vs_variable_report.py
+++ b/api/tests/test_fixed_vs_variable_report.py
@@ -6,11 +6,10 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from my_private_finances.api.routes.reports import get_fixed_vs_variable
 from my_private_finances.models import Account, Category, Transaction
+from my_private_finances.services.reporting import AccountNotFound, fixed_vs_variable
 
 
 async def _seed(session: AsyncSession) -> tuple[Account, Category, Category, Category]:
@@ -64,10 +63,10 @@ async def test_fixed_vs_variable_basic(db_session: AsyncSession) -> None:
     )
     await db_session.commit()
 
-    result = await get_fixed_vs_variable(
-        account_id=acc.id,
+    result = await fixed_vs_variable(
+        db_session,
         month="2026-05",
-        session=db_session,  # type: ignore[arg-type]
+        account_id=acc.id,
     )
 
     assert result.account_id == acc.id
@@ -82,10 +81,10 @@ async def test_fixed_vs_variable_basic(db_session: AsyncSession) -> None:
 async def test_fixed_vs_variable_no_expenses(db_session: AsyncSession) -> None:
     acc, _, _, _ = await _seed(db_session)
 
-    result = await get_fixed_vs_variable(
-        account_id=acc.id,
+    result = await fixed_vs_variable(
+        db_session,
         month="2026-05",
-        session=db_session,  # type: ignore[arg-type]
+        account_id=acc.id,
     )
 
     assert result.fixed_total == Decimal("0")
@@ -106,10 +105,10 @@ async def test_fixed_vs_variable_ignores_income(db_session: AsyncSession) -> Non
     )
     await db_session.commit()
 
-    result = await get_fixed_vs_variable(
-        account_id=acc.id,
+    result = await fixed_vs_variable(
+        db_session,
         month="2026-05",
-        session=db_session,  # type: ignore[arg-type]
+        account_id=acc.id,
     )
 
     assert result.fixed_total == Decimal("500.00")
@@ -117,8 +116,5 @@ async def test_fixed_vs_variable_ignores_income(db_session: AsyncSession) -> Non
 
 @pytest.mark.asyncio
 async def test_fixed_vs_variable_account_not_found(db_session: AsyncSession) -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        await get_fixed_vs_variable(
-            account_id=99999, month="2026-05", session=db_session
-        )
-    assert exc_info.value.status_code == 404
+    with pytest.raises(AccountNotFound):
+        await fixed_vs_variable(db_session, month="2026-05", account_id=99999)

--- a/api/tests/test_reporting_service.py
+++ b/api/tests/test_reporting_service.py
@@ -1,0 +1,222 @@
+"""Service-level tests for my_private_finances.services.reporting (issue #104).
+
+These call the aggregation functions directly (not via HTTP) so the branch
+coverage registers with pytest-cov.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from my_private_finances.models import Account, Category, Transaction
+from my_private_finances.services import reporting
+from my_private_finances.services.reporting import AccountNotFound
+
+
+async def _account(
+    session: AsyncSession,
+    *,
+    name: str = "Main",
+    currency: str = "EUR",
+    opening_balance: str | None = None,
+    opening_balance_date: date | None = None,
+) -> Account:
+    acc = Account(
+        name=name,
+        currency=currency,
+        opening_balance=Decimal(opening_balance) if opening_balance else None,
+        opening_balance_date=opening_balance_date,
+    )
+    session.add(acc)
+    await session.commit()
+    await session.refresh(acc)
+    return acc
+
+
+async def _category(
+    session: AsyncSession, name: str, cost_type: str | None = None
+) -> Category:
+    cat = Category(name=name, cost_type=cost_type)
+    session.add(cat)
+    await session.commit()
+    await session.refresh(cat)
+    return cat
+
+
+_HASH = 0
+
+
+def _tx(
+    account_id: int,
+    booking_date: date,
+    amount: str,
+    *,
+    category_id: int | None = None,
+    payee: str = "Shop",
+    is_transfer: bool = False,
+) -> Transaction:
+    global _HASH
+    _HASH += 1
+    return Transaction(
+        account_id=account_id,
+        booking_date=booking_date,
+        amount=Decimal(amount),
+        currency="EUR",
+        payee=payee,
+        purpose="p",
+        import_source="manual",
+        import_hash=f"rs-{_HASH}",
+        category_id=category_id,
+        is_transfer=is_transfer,
+    )
+
+
+@pytest.mark.asyncio
+async def test_monthly_report_aggregates_and_filters(db_session: AsyncSession) -> None:
+    acc = await _account(db_session)
+    other = await _account(db_session, name="Other")
+    cat = await _category(db_session, "Groceries")
+    db_session.add_all(
+        [
+            _tx(acc.id, date(2026, 2, 3), "-12.34", category_id=cat.id, payee="REWE"),
+            _tx(acc.id, date(2026, 2, 4), "2500.00", payee="Employer"),
+            _tx(acc.id, date(2026, 1, 15), "-99.99"),  # other month
+            _tx(acc.id, date(2026, 2, 9), "-500.00", is_transfer=True),  # excluded
+            _tx(other.id, date(2026, 2, 9), "-1.00"),  # other account
+        ]
+    )
+    await db_session.commit()
+
+    report = await reporting.monthly_report(
+        db_session, month="2026-02", account_id=acc.id
+    )
+    assert report.currency == "EUR"
+    assert report.transactions_count == 2
+    assert report.income_total == Decimal("2500.00")
+    assert report.expense_total == Decimal("-12.34")
+    assert report.net_total == Decimal("2487.66")
+    assert report.category_breakdown[0].category_name == "Groceries"
+    assert report.top_spendings[0].payee == "REWE"
+
+
+@pytest.mark.asyncio
+async def test_monthly_report_all_accounts_defaults_to_eur(
+    db_session: AsyncSession,
+) -> None:
+    await _account(db_session, currency="USD")
+    report = await reporting.monthly_report(db_session, month="2026-02")
+    assert report.currency == "EUR"
+    assert report.account_id is None
+
+
+@pytest.mark.asyncio
+async def test_monthly_report_unknown_account(db_session: AsyncSession) -> None:
+    with pytest.raises(AccountNotFound):
+        await reporting.monthly_report(db_session, month="2026-02", account_id=4242)
+
+
+@pytest.mark.asyncio
+async def test_spending_trend_averages(db_session: AsyncSession) -> None:
+    acc = await _account(db_session)
+    cat = await _category(db_session, "Food")
+    for d, amt in [
+        (date(2025, 11, 5), "-100.00"),
+        (date(2025, 12, 5), "-200.00"),
+        (date(2026, 1, 5), "-300.00"),
+        (date(2026, 2, 5), "-150.00"),
+    ]:
+        db_session.add(_tx(acc.id, d, amt, category_id=cat.id))
+    await db_session.commit()
+
+    report = await reporting.spending_trend(
+        db_session, month="2026-02", lookback_months=3, account_id=acc.id
+    )
+    assert len(report.categories) == 1
+    item = report.categories[0]
+    assert item.category_name == "Food"
+    assert item.avg_monthly == Decimal("200.00")
+    assert item.current_month == Decimal("150.00")
+    assert item.projected >= item.current_month
+
+
+@pytest.mark.asyncio
+async def test_spending_trend_empty(db_session: AsyncSession) -> None:
+    acc = await _account(db_session)
+    report = await reporting.spending_trend(
+        db_session, month="2026-02", account_id=acc.id
+    )
+    assert report.categories == []
+    assert report.total_avg_monthly == Decimal("0.00")
+
+
+@pytest.mark.asyncio
+async def test_annual_report_monthly_breakdown(db_session: AsyncSession) -> None:
+    acc = await _account(db_session)
+    db_session.add_all(
+        [
+            _tx(acc.id, date(2026, 1, 5), "2500.00"),
+            _tx(acc.id, date(2026, 1, 20), "-800.00"),
+            _tx(acc.id, date(2025, 12, 31), "-999.00"),  # other year
+            _tx(acc.id, date(2026, 3, 3), "-100.00", is_transfer=True),  # excluded
+        ]
+    )
+    await db_session.commit()
+
+    report = await reporting.annual_report(db_session, year=2026, account_id=acc.id)
+    assert len(report.months) == 12
+    jan = next(m for m in report.months if m.month == "2026-01")
+    assert jan.income == Decimal("2500.00")
+    assert jan.expenses == Decimal("800.00")
+    assert jan.net == Decimal("1700.00")
+    assert jan.savings_rate == Decimal("68.00")
+    assert report.total_expenses == Decimal("800.00")
+
+
+@pytest.mark.asyncio
+async def test_annual_report_defaults_year_and_validates_account(
+    db_session: AsyncSession,
+) -> None:
+    report = await reporting.annual_report(db_session)
+    assert report.year == date.today().year
+    with pytest.raises(AccountNotFound):
+        await reporting.annual_report(db_session, year=2026, account_id=999)
+
+
+@pytest.mark.asyncio
+async def test_net_worth_report_no_accounts(db_session: AsyncSession) -> None:
+    report = await reporting.net_worth_report(db_session, months=6)
+    assert report.current_total == Decimal("0")
+    assert report.accounts == []
+    assert report.history == []
+
+
+@pytest.mark.asyncio
+async def test_net_worth_report_with_opening_balance(db_session: AsyncSession) -> None:
+    acc = await _account(
+        db_session,
+        opening_balance="1000.00",
+        opening_balance_date=date(2026, 1, 1),
+    )
+    db_session.add_all(
+        [
+            _tx(acc.id, date(2026, 1, 10), "500.00"),
+            _tx(acc.id, date(2026, 1, 20), "-200.00"),
+            _tx(acc.id, date(2026, 1, 15), "-50.00", is_transfer=True),  # excluded
+        ]
+    )
+    await db_session.commit()
+
+    report = await reporting.net_worth_report(db_session, months=3)
+    assert len(report.accounts) == 1
+    summary = report.accounts[0]
+    assert summary.opening_balance == Decimal("1000.00")
+    # 1000 + 500 - 200 = 1300 (transfer excluded)
+    assert summary.current_balance == Decimal("1300.00")
+    assert report.current_total == Decimal("1300.00")
+    assert report.history[-1].month == reporting._month_key(
+        reporting._target_months(3)[-1]
+    )


### PR DESCRIPTION
Closes #104 (findings A1, C4).

## What

Reporting SQL used to be built inline in six route handlers across four
modules. It now lives in `services/reporting.py`; the routes are thin
adapters.

| Module | before | after |
|---|--:|--:|
| `routes/reports.py` | 298 | 45 |
| `routes/trends.py` | 155 | 26 |
| `routes/annual.py` | 108 | 20 |
| `routes/net_worth.py` | 187 | 31 |

## Details

- **`services/reporting.py`** — one `async` function per report
  (`monthly_report`, `budget_vs_actual`, `fixed_vs_variable`,
  `spending_trend`, `annual_report`, `net_worth_report`), each taking an
  `AsyncSession` and returning the existing typed response schema.
- **`non_transfer_filter(account_id, start, end, expenses_only)`** builds
  the shared `is_transfer == False` + month-window + account-scope filter
  once (C4). `parse_month` / `resolve_currency` moved here too.
- **Typed errors** — `ReportError` base with `InvalidMonth` (422) and
  `AccountNotFound` (404); one `create_app` exception handler maps them to
  JSON `{"detail": ...}`. Same HTTP status codes as before; no API change.
- **Tests** — new `tests/test_reporting_service.py` exercises every
  aggregation directly (HTTP tests don't register with pytest-cov). Net
  worth had **zero** tests before; it has coverage now. The two existing
  direct-call report tests were repointed at the service functions.

## Verification

- `ruff check` + `ruff format --check` clean
- `mypy my_private_finances` — Success (72 files)
- `pytest` — 277 passed; coverage **82%** (gate 76)
- `alembic check` — no drift (no model changes)

No DB migration. HTTP contract unchanged (paths, params, response models,
status codes all identical).

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm