### PR TITLE
refactor(api): schema-driven responses, drop _to_read boilerplate (#105)

### DIFF
--- a/api/my_private_finances/api/routes/accounts.py
+++ b/api/my_private_finances/api/routes/accounts.py
@@ -12,32 +12,21 @@ from my_private_finances.schemas import AccountCreate, AccountRead, AccountUpdat
 router = APIRouter(prefix="/accounts", tags=["accounts"])
 
 
-def _to_read(a: Account) -> AccountRead:
-    assert a.id is not None
-    return AccountRead(
-        id=a.id,
-        name=a.name,
-        currency=a.currency,
-        opening_balance=a.opening_balance,
-        opening_balance_date=a.opening_balance_date,
-    )
-
-
 @router.post("", response_model=AccountRead, status_code=201)
 async def create_account(
     account: Annotated[AccountCreate, Body()], session: SessionDep
-):
+) -> Account:
     db_obj = Account(name=account.name, currency=account.currency)
     session.add(db_obj)
     await session.commit()
     await session.refresh(db_obj)
-    return _to_read(db_obj)
+    return db_obj
 
 
 @router.get("", response_model=list[AccountRead])
-async def list_accounts(session: SessionDep):
+async def list_accounts(session: SessionDep) -> list[Account]:
     res = await session.execute(select(Account).order_by(Account.id))  # type: ignore[arg-type]
-    return [_to_read(a) for a in res.scalars().all()]
+    return list(res.scalars().all())
 
 
 @router.patch("/{account_id}", response_model=AccountRead)
@@ -45,7 +34,7 @@ async def update_account(
     account_id: int,
     payload: Annotated[AccountUpdate, Body()],
     session: SessionDep,
-):
+) -> Account:
     db_obj = await session.get(Account, account_id)
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Account not found")
@@ -57,4 +46,4 @@ async def update_account(
 
     await session.commit()
     await session.refresh(db_obj)
-    return _to_read(db_obj)
+    return db_obj

--- a/api/my_private_finances/api/routes/categories.py
+++ b/api/my_private_finances/api/routes/categories.py
@@ -13,17 +13,10 @@ from my_private_finances.schemas import CategoryCreate, CategoryRead, CategoryUp
 router = APIRouter(prefix="/categories", tags=["categories"])
 
 
-def _to_read(cat: Category) -> CategoryRead:
-    assert cat.id is not None
-    return CategoryRead(
-        id=cat.id, name=cat.name, parent_id=cat.parent_id, cost_type=cat.cost_type
-    )
-
-
 @router.post("", response_model=CategoryRead, status_code=201)
 async def create_category(
     category: Annotated[CategoryCreate, Body()], session: SessionDep
-):
+) -> Category:
     if category.parent_id is not None:
         parent = await session.get(Category, category.parent_id)
         if parent is None:
@@ -37,13 +30,13 @@ async def create_category(
     session.add(db_obj)
     await session.commit()
     await session.refresh(db_obj)
-    return _to_read(db_obj)
+    return db_obj
 
 
 @router.get("", response_model=list[CategoryRead])
-async def list_categories(session: SessionDep):
+async def list_categories(session: SessionDep) -> list[Category]:
     res = await session.execute(select(Category).order_by(Category.name))  # type: ignore[arg-type]
-    return [_to_read(c) for c in res.scalars().all()]
+    return list(res.scalars().all())
 
 
 @router.patch("/{category_id}", response_model=CategoryRead)
@@ -51,7 +44,7 @@ async def update_category(
     category_id: int,
     payload: Annotated[CategoryUpdate, Body()],
     session: SessionDep,
-):
+) -> Category:
     db_obj = await session.get(Category, category_id)
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Category not found")
@@ -74,11 +67,11 @@ async def update_category(
 
     await session.commit()
     await session.refresh(db_obj)
-    return _to_read(db_obj)
+    return db_obj
 
 
 @router.delete("/{category_id}", status_code=204)
-async def delete_category(category_id: int, session: SessionDep):
+async def delete_category(category_id: int, session: SessionDep) -> None:
     db_obj = await session.get(Category, category_id)
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Category not found")

--- a/api/my_private_finances/api/routes/categorization_rules.py
+++ b/api/my_private_finances/api/routes/categorization_rules.py
@@ -19,20 +19,10 @@ from my_private_finances.services.categorization import apply_rules_to_uncategor
 router = APIRouter(prefix="/categorization-rules", tags=["categorization-rules"])
 
 
-def _to_read(rule: CategorizationRule) -> RuleRead:
-    assert rule.id is not None
-    return RuleRead(
-        id=rule.id,
-        position=rule.position,
-        field=rule.field,
-        operator=rule.operator,
-        value=rule.value,
-        category_id=rule.category_id,
-    )
-
-
 @router.post("", response_model=RuleRead, status_code=201)
-async def create_rule(payload: Annotated[RuleCreate, Body()], session: SessionDep):
+async def create_rule(
+    payload: Annotated[RuleCreate, Body()], session: SessionDep
+) -> CategorizationRule:
     # Validate category exists
     cat = await session.get(Category, payload.category_id)
     if cat is None:
@@ -55,15 +45,15 @@ async def create_rule(payload: Annotated[RuleCreate, Body()], session: SessionDe
     session.add(db_obj)
     await session.commit()
     await session.refresh(db_obj)
-    return _to_read(db_obj)
+    return db_obj
 
 
 @router.get("", response_model=list[RuleRead])
-async def list_rules(session: SessionDep):
+async def list_rules(session: SessionDep) -> list[CategorizationRule]:
     result = await session.execute(
         select(CategorizationRule).order_by(CategorizationRule.position)  # type: ignore[arg-type]
     )
-    return [_to_read(r) for r in result.scalars().all()]
+    return list(result.scalars().all())
 
 
 @router.patch("/{rule_id}", response_model=RuleRead)
@@ -71,7 +61,7 @@ async def update_rule(
     rule_id: int,
     payload: Annotated[RuleUpdate, Body()],
     session: SessionDep,
-):
+) -> CategorizationRule:
     db_obj = await session.get(CategorizationRule, rule_id)
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Rule not found")
@@ -90,11 +80,11 @@ async def update_rule(
 
     await session.commit()
     await session.refresh(db_obj)
-    return _to_read(db_obj)
+    return db_obj
 
 
 @router.delete("/{rule_id}", status_code=204)
-async def delete_rule(rule_id: int, session: SessionDep):
+async def delete_rule(rule_id: int, session: SessionDep) -> None:
     db_obj = await session.get(CategorizationRule, rule_id)
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Rule not found")
@@ -104,7 +94,9 @@ async def delete_rule(rule_id: int, session: SessionDep):
 
 
 @router.put("/reorder", response_model=list[RuleRead])
-async def reorder_rules(payload: Annotated[RuleReorder, Body()], session: SessionDep):
+async def reorder_rules(
+    payload: Annotated[RuleReorder, Body()], session: SessionDep
+) -> list[CategorizationRule]:
     # Load all rules
     result = await session.execute(select(CategorizationRule))
     rules_by_id = {r.id: r for r in result.scalars().all()}
@@ -126,11 +118,10 @@ async def reorder_rules(payload: Annotated[RuleReorder, Body()], session: Sessio
     await session.commit()
 
     # Return in new order
-    ordered = sorted(rules_by_id.values(), key=lambda r: r.position)
-    return [_to_read(r) for r in ordered]
+    return sorted(rules_by_id.values(), key=lambda r: r.position)
 
 
 @router.post("/apply", response_model=ApplyResult)
-async def apply_rules(session: SessionDep):
+async def apply_rules(session: SessionDep) -> ApplyResult:
     categorized = await apply_rules_to_uncategorized(session)
     return ApplyResult(categorized=categorized)

--- a/api/my_private_finances/api/routes/csv_profiles.py
+++ b/api/my_private_finances/api/routes/csv_profiles.py
@@ -20,18 +20,6 @@ router = APIRouter(prefix="/csv-profiles", tags=["csv-profiles"])
 logger = logging.getLogger(__name__)
 
 
-def _to_read(profile: CsvProfile) -> CsvProfileRead:
-    assert profile.id is not None
-    return CsvProfileRead(
-        id=profile.id,
-        name=profile.name,
-        delimiter=profile.delimiter,
-        date_format=profile.date_format,
-        decimal_comma=profile.decimal_comma,
-        column_map=profile.column_map,
-    )
-
-
 @router.get("", response_model=list[CsvProfileRead])
 async def list_csv_profiles(session: SessionDep) -> list[CsvProfileRead]:
     profiles = (
@@ -39,7 +27,7 @@ async def list_csv_profiles(session: SessionDep) -> list[CsvProfileRead]:
         .scalars()
         .all()
     )
-    return [_to_read(p) for p in profiles]
+    return [CsvProfileRead.model_validate(p) for p in profiles]
 
 
 @router.post("", response_model=CsvProfileRead, status_code=201)
@@ -64,7 +52,7 @@ async def create_csv_profile(
         ) from e
     await session.refresh(db_obj)
     logger.info("CSV profile created: id=%d, name=%r", db_obj.id, db_obj.name)
-    return _to_read(db_obj)
+    return CsvProfileRead.model_validate(db_obj)
 
 
 @router.get("/{profile_id}", response_model=CsvProfileRead)
@@ -72,7 +60,7 @@ async def get_csv_profile(profile_id: int, session: SessionDep) -> CsvProfileRea
     db_obj = await session.get(CsvProfile, profile_id)
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Profile not found")
-    return _to_read(db_obj)
+    return CsvProfileRead.model_validate(db_obj)
 
 
 @router.put("/{profile_id}", response_model=CsvProfileRead)
@@ -106,7 +94,7 @@ async def update_csv_profile(
 
     await session.refresh(db_obj)
     logger.info("CSV profile updated: id=%d, name=%r", db_obj.id, db_obj.name)
-    return _to_read(db_obj)
+    return CsvProfileRead.model_validate(db_obj)
 
 
 @router.delete("/{profile_id}", status_code=204)

--- a/api/my_private_finances/api/routes/transactions.py
+++ b/api/my_private_finances/api/routes/transactions.py
@@ -73,20 +73,7 @@ async def create_transaction(
     if db_obj.id is None:
         raise HTTPException(status_code=500, detail="Transaction ID not assigned")
 
-    return TransactionRead(
-        id=db_obj.id,
-        account_id=db_obj.account_id,
-        booking_date=db_obj.booking_date,
-        amount=db_obj.amount,
-        currency=db_obj.currency,
-        payee=db_obj.payee,
-        purpose=db_obj.purpose,
-        category_id=db_obj.category_id,
-        external_id=db_obj.external_id,
-        import_source=db_obj.import_source,
-        import_hash=db_obj.import_hash,
-        is_transfer=db_obj.is_transfer,
-    )
+    return TransactionRead.model_validate(db_obj)
 
 
 @router.patch("/{transaction_id}", response_model=TransactionRead)
@@ -110,21 +97,7 @@ async def update_transaction(
     await session.commit()
     await session.refresh(db_obj)
 
-    assert db_obj.id is not None
-    return TransactionRead(
-        id=db_obj.id,
-        account_id=db_obj.account_id,
-        booking_date=db_obj.booking_date,
-        amount=db_obj.amount,
-        currency=db_obj.currency,
-        payee=db_obj.payee,
-        purpose=db_obj.purpose,
-        category_id=db_obj.category_id,
-        external_id=db_obj.external_id,
-        import_source=db_obj.import_source,
-        import_hash=db_obj.import_hash,
-        is_transfer=db_obj.is_transfer,
-    )
+    return TransactionRead.model_validate(db_obj)
 
 
 @router.get("", response_model=TransactionListResponse)
@@ -184,27 +157,6 @@ async def list_transactions(
     )
 
     res = await session.execute(stmt)
-    rows = list(res.scalars().all())
-
-    items: list[TransactionRead] = []
-    for row in rows:
-        if row.id is None:
-            continue
-        items.append(
-            TransactionRead(
-                id=row.id,
-                account_id=row.account_id,
-                booking_date=row.booking_date,
-                amount=row.amount,
-                currency=row.currency,
-                payee=row.payee,
-                purpose=row.purpose,
-                category_id=row.category_id,
-                external_id=row.external_id,
-                import_source=row.import_source,
-                import_hash=row.import_hash,
-                is_transfer=row.is_transfer,
-            )
-        )
+    items = [TransactionRead.model_validate(row) for row in res.scalars().all()]
 
     return TransactionListResponse(items=items, total=total)

--- a/api/my_private_finances/schemas/__init__.py
+++ b/api/my_private_finances/schemas/__init__.py
@@ -1,5 +1,5 @@
 from .account import AccountCreate, AccountRead, AccountUpdate
-from .base import StrictSchema
+from .base import ReadSchema, StrictSchema
 from .budget import BudgetCreate, BudgetRead, BudgetUpdate
 from .categorization_rule import (
     ApplyResult,
@@ -69,6 +69,7 @@ __all__ = [
     "TransactionUpdate",
     "TransactionListResponse",
     "StrictSchema",
+    "ReadSchema",
     "MonthlyReport",
     "PayeeTotal",
     "TopSpending",

--- a/api/my_private_finances/schemas/account.py
+++ b/api/my_private_finances/schemas/account.py
@@ -4,9 +4,9 @@ from datetime import date
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from my_private_finances.schemas.base import StrictSchema
+from my_private_finances.schemas.base import ReadSchema, StrictSchema
 
 
 class AccountCreate(StrictSchema):
@@ -19,7 +19,7 @@ class AccountUpdate(StrictSchema):
     opening_balance_date: Optional[date] = None
 
 
-class AccountRead(BaseModel):
+class AccountRead(ReadSchema):
     id: int
     name: str
     currency: str

--- a/api/my_private_finances/schemas/base.py
+++ b/api/my_private_finances/schemas/base.py
@@ -1,8 +1,28 @@
+"""Shared base classes for request and response schemas (issue #105).
+
+Policy:
+
+* **Request bodies** (`*Create`, `*Update`, reorder payloads, …) subclass
+  :class:`StrictSchema` — unknown fields are rejected (``extra="forbid"``) so a
+  typo in a client payload is a 422, not a silent no-op.
+* **Responses** (`*Read`, report DTOs, …) subclass :class:`ReadSchema` —
+  ``from_attributes=True`` lets a handler ``return`` the ORM object (or
+  ``Schema.model_validate(obj)``) instead of hand-writing a field-by-field
+  ``_to_read`` mapper. Enrichment mappers (joining a name, computing a derived
+  field) still live in the route/service layer.
+"""
+
 from typing import Any, cast
 
-from pydantic import ConfigDict
+from pydantic import BaseModel, ConfigDict
 from sqlmodel import SQLModel
 
 
 class StrictSchema(SQLModel):
     model_config = cast(Any, ConfigDict(extra="forbid"))
+
+
+class ReadSchema(BaseModel):
+    """Base for response models: validated straight from ORM attributes."""
+
+    model_config = ConfigDict(from_attributes=True)

--- a/api/my_private_finances/schemas/categorization_rule.py
+++ b/api/my_private_finances/schemas/categorization_rule.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
-from my_private_finances.schemas.base import StrictSchema
+from my_private_finances.schemas.base import ReadSchema, StrictSchema
 
 FieldName = Literal["payee", "purpose", "amount"]
 Operator = Literal[
@@ -34,7 +34,7 @@ class RuleUpdate(StrictSchema):
     category_id: Optional[int] = None
 
 
-class RuleRead(BaseModel):
+class RuleRead(ReadSchema):
     id: int
     position: int
     field: str

--- a/api/my_private_finances/schemas/category.py
+++ b/api/my_private_finances/schemas/category.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from my_private_finances.schemas.base import StrictSchema
+from my_private_finances.schemas.base import ReadSchema, StrictSchema
 
 CostType = Literal["fixed", "variable"]
 
@@ -21,7 +21,7 @@ class CategoryUpdate(StrictSchema):
     cost_type: Optional[CostType] = None
 
 
-class CategoryRead(BaseModel):
+class CategoryRead(ReadSchema):
     id: int
     name: str
     parent_id: Optional[int] = None

--- a/api/my_private_finances/schemas/csv_profile.py
+++ b/api/my_private_finances/schemas/csv_profile.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 # Valid field names that can be remapped via column_map
 REMAPPABLE_FIELDS = frozenset(
@@ -23,6 +23,8 @@ class CsvProfileCreate(BaseModel):
 
 class CsvProfileRead(CsvProfileCreate):
     id: int
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CsvProfileUpdate(BaseModel):

--- a/api/my_private_finances/schemas/transaction_read.py
+++ b/api/my_private_finances/schemas/transaction_read.py
@@ -2,10 +2,12 @@ from datetime import date
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel, field_serializer
+from pydantic import field_serializer
+
+from my_private_finances.schemas.base import ReadSchema
 
 
-class TransactionRead(BaseModel):
+class TransactionRead(ReadSchema):
     id: int
     account_id: int
     booking_date: date


### PR DESCRIPTION
Closes #105 (findings C2, C13).

## What

`_to_read` field-by-field mappers lived in 6 route files; `transactions.py`
constructed `TransactionRead(...)` by hand 3×. This standardises on
schema-driven serialisation.

- **`schemas/base.py`** — new `ReadSchema` base (`from_attributes=True`) and
  the request/response policy written down:
  - request bodies (`*Create` / `*Update`) → `StrictSchema` (`extra="forbid"`)
  - responses (`*Read`) → `ReadSchema`, validated straight from ORM objects
- **Schemas moved to `ReadSchema`**: `AccountRead`, `CategoryRead`,
  `RuleRead`, `TransactionRead`; `CsvProfileRead` gets `from_attributes`.
- **`_to_read` deleted** in `accounts.py`, `categories.py`,
  `categorization_rules.py`, `csv_profiles.py`. Handlers return the ORM
  object (FastAPI serialises via `response_model`), or
  `TransactionRead.model_validate(obj)` where a field serializer is in play.
- Added the missing endpoint return-type annotations.
- Bonus fix: `CsvProfileRead` now returns `row_filters` /
  `row_exclude_filters` — the old mapper dropped them.

## Deliberately not touched

`budgets._to_read`, `recurring_patterns._to_read`,
`transfers._candidate_to_read` join a category name or compute derived
fields (`next_due`, `is_overdue`, `annual_amount`). They are enrichment, not
boilerplate — flagged for a later service extraction rather than forced into
this pattern.

## Verification

- `ruff check` + `ruff format --check` clean
- `mypy my_private_finances` — Success (71 files)
- `pytest` — 276 passed; coverage 77% (gate 76)
- `alembic check` — no drift (no model changes)

HTTP contract unchanged (paths, params, response models, status codes).

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm