### PR TITLE
refactor(api): replace cast(Any).__table__ with typed table() helper (#106)

### DIFF
--- a/api/my_private_finances/api/routes/recurring_patterns.py
+++ b/api/my_private_finances/api/routes/recurring_patterns.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Annotated, Any, cast
+from typing import Annotated
 
 from fastapi import APIRouter, Body, HTTPException
 from fastapi.params import Query
@@ -20,6 +20,7 @@ from my_private_finances.schemas import (
 from my_private_finances.services.recurring_detection import run_detection
 from my_private_finances.utils.db_helpers import get_account_or_404
 from my_private_finances.utils.money import money_from_db
+from my_private_finances.utils.sql import table
 
 router = APIRouter(prefix="/recurring-patterns", tags=["recurring-patterns"])
 
@@ -141,7 +142,7 @@ async def get_recurring_summary(
 ) -> RecurringSummary:
     await get_account_or_404(session, account_id)
 
-    rp = cast(Any, RecurringPattern).__table__
+    rp = table(RecurringPattern)
 
     stmt = (
         select(

--- a/api/my_private_finances/api/routes/transfers.py
+++ b/api/my_private_finances/api/routes/transfers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, cast
+from typing import Annotated
 
 from fastapi import APIRouter, HTTPException
 from fastapi.params import Query
@@ -16,6 +16,7 @@ from my_private_finances.services.transfer_detection import (
     detect_transfer_candidates,
     dismiss_transfer,
 )
+from my_private_finances.utils.sql import table
 
 router = APIRouter(prefix="/transfers", tags=["transfers"])
 
@@ -100,7 +101,7 @@ async def trigger_detection(
     await session.commit()
 
     # Reload with IDs after commit
-    tc = cast(Any, TransferCandidate).__table__
+    tc = table(TransferCandidate)
     stmt = (
         select(tc)
         .where(tc.c.status == "pending")
@@ -121,7 +122,7 @@ async def list_candidates(
     status: Annotated[str | None, Query()] = None,
 ) -> list[TransferCandidateRead]:
     """List transfer candidates. Defaults to pending if no status filter given."""
-    tc = cast(Any, TransferCandidate).__table__
+    tc = table(TransferCandidate)
     stmt = select(tc)
     filter_status = status if status is not None else "pending"
     stmt = stmt.where(tc.c.status == filter_status).order_by(tc.c.id)

--- a/api/my_private_finances/services/recurring_detection.py
+++ b/api/my_private_finances/services/recurring_detection.py
@@ -6,13 +6,13 @@ import logging
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
-from typing import Any, cast
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from my_private_finances.models import RecurringPattern, Transaction
 from my_private_finances.utils.money import money_from_db
+from my_private_finances.utils.sql import table
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +151,7 @@ async def fetch_transaction_groups(
     account_id: int,
 ) -> dict[str, list[tuple[date, Decimal, int | None]]]:
     """Fetch and group expense transactions by normalized payee."""
-    tx = cast(Any, Transaction).__table__
+    tx = table(Transaction)
 
     stmt = (
         select(

--- a/api/my_private_finances/services/reporting.py
+++ b/api/my_private_finances/services/reporting.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import calendar
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 from sqlalchemy import ColumnElement, and_, case, func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,6 +36,7 @@ from my_private_finances.schemas import (
     TopSpending,
 )
 from my_private_finances.utils.money import money_from_db
+from my_private_finances.utils.sql import table
 
 _ZERO = Decimal("0")
 _CENTS = Decimal("0.01")
@@ -60,9 +61,9 @@ class AccountNotFound(ReportError):
 # Shared helpers
 # --------------------------------------------------------------------------- #
 
-_TX = cast(Any, Transaction).__table__
-_CAT = cast(Any, Category).__table__
-_BUDGET = cast(Any, Budget).__table__
+_TX = table(Transaction)
+_CAT = table(Category)
+_BUDGET = table(Budget)
 
 
 def parse_month(value: str) -> tuple[date, date]:

--- a/api/my_private_finances/services/transfer_detection.py
+++ b/api/my_private_finances/services/transfer_detection.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 from decimal import Decimal
-from typing import Any, cast
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from my_private_finances.models import Account, Transaction
 from my_private_finances.models.transfer_candidate import TransferCandidate
 from my_private_finances.utils.money import money_from_db
+from my_private_finances.utils.sql import table
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +34,8 @@ async def detect_transfer_candidates(
     Skips pairs that are already in TransferCandidate (any status).
     Returns newly created TransferCandidate rows (status='pending').
     """
-    tx = cast(Any, Transaction).__table__
-    acc = cast(Any, Account).__table__
+    tx = table(Transaction)
+    acc = table(Account)
 
     # Load all transactions with account info
     stmt = (
@@ -61,7 +61,7 @@ async def detect_transfer_candidates(
     incoming = [r for r in rows if r.amount > 0]
 
     # Load already-tracked pairs to avoid duplicates
-    tc = cast(Any, TransferCandidate).__table__
+    tc = table(TransferCandidate)
     existing_stmt = select(tc.c.from_transaction_id, tc.c.to_transaction_id)
     existing_rows = (await session.execute(existing_stmt)).all()
     existing_pairs: set[tuple[int, int]] = {

--- a/api/my_private_finances/utils/sql.py
+++ b/api/my_private_finances/utils/sql.py
@@ -1,0 +1,24 @@
+"""Query-building helpers (review finding C1 / issue #106).
+
+`cast(Any, Model).__table__` appeared ~19 times across the query code. SQLModel
+does not expose ``__table__`` to the type checker, and this project doesn't run
+the (deprecated) SQLAlchemy mypy plugin, so Core-style selects that need
+``func.sum(t.c.amount)`` etc. otherwise reach for a per-call ``cast``.
+
+:func:`table` centralises that into one named, greppable escape hatch. Column
+access through the returned object is still ``Any``-typed, but the pattern lives
+in exactly one place and can be swapped for a fully-typed implementation if the
+tooling improves. Plain ORM selects (``select(Model).where(Model.x == y)``)
+should use the model attributes directly and not this helper.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlmodel import SQLModel
+
+
+def table(model: type[SQLModel]) -> Any:
+    """Return a model's Core ``Table`` for column-level query building."""
+    return model.__table__  # type: ignore[attr-defined]

--- a/api/tests/test_sql_helper.py
+++ b/api/tests/test_sql_helper.py
@@ -1,0 +1,36 @@
+"""Tests for the `table()` query helper and the C1 escape-hatch budget (#106)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import Table
+
+from my_private_finances.models import Transaction
+from my_private_finances.utils.sql import table
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent / "my_private_finances"
+
+
+def test_table_returns_the_core_table() -> None:
+    t = table(Transaction)
+    assert isinstance(t, Table)
+    assert t is Transaction.__table__  # type: ignore[attr-defined]
+    # Column-level access still works for Core-style query building.
+    assert "amount" in t.c
+    assert "is_transfer" in t.c
+
+
+def test_no_raw_dunder_table_access_outside_the_helper() -> None:
+    """`.__table__` must only be reached through `utils/sql.py::table` (C1).
+
+    Keeps the count of the `cast(Any, Model).__table__` escape hatch at its
+    documented minimum: one, inside the helper.
+    """
+    offenders: list[str] = []
+    for path in _PKG_ROOT.rglob("*.py"):
+        if path.name == "sql.py" and path.parent.name == "utils":
+            continue
+        if "__table__" in path.read_text():
+            offenders.append(str(path.relative_to(_PKG_ROOT)))
+    assert not offenders, f"Use utils.sql.table() instead of .__table__ in: {offenders}"


### PR DESCRIPTION
Closes #106 (finding C1).

Rebased onto `main` after #137/#138 merged — the diff is now just the #106 change.

## What

`cast(Any, Model).__table__` appeared ~19× across 8 files. It's needed because
SQLModel doesn't expose `__table__` to mypy and Core selects with
`func.sum(t.c.amount)` don't satisfy `select()`'s overloads without the
deprecated SQLAlchemy mypy plugin — but `cast(Any, …)` makes the *entire* query
untyped.

- **`utils/sql.py::table(model)`** — one named, documented, greppable escape
  hatch. The `# type: ignore[attr-defined]` lives here only.
- Call sites updated: `services/reporting.py`, `services/transfer_detection.py`,
  `services/recurring_detection.py`, `routes/transfers.py`,
  `routes/recurring_patterns.py`. Unused `Any` / `cast` imports dropped.
- **`tests/test_sql_helper.py`** — asserts `table()` returns the Core `Table`,
  and a guard test that `.__table__` appears nowhere in the package outside the
  helper (keeps the C1 count at its documented minimum: 1).

Not in scope: `schemas/base.py`'s `cast(Any, ConfigDict(...))` — a pydantic
config-typing workaround, unrelated to C1. Plain ORM selects already use model
attributes directly and are untouched.

## Verification

- `ruff check` + `ruff format --check` clean
- `mypy my_private_finances` — Success (73 files)
- `pytest` — 278 passed; coverage 82%
- `alembic check` — no drift

SQL strings and HTTP contract unchanged.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm