### PR TITLE
refactor(api): typed service exceptions + central HTTP mapping (#107)

### DIFF
--- a/api/my_private_finances/api/routes/imports.py
+++ b/api/my_private_finances/api/routes/imports.py
@@ -14,6 +14,7 @@ from my_private_finances.services.csv_import import (
     ColumnMap,
     import_transactions_from_csv_path,
 )
+from my_private_finances.services.exceptions import NotFoundError, ServiceError
 from my_private_finances.services.recurring_detection import run_detection
 
 router = APIRouter(prefix="/imports", tags=["imports"])
@@ -106,9 +107,7 @@ async def _run_import(
     if profile_id is not None:
         profile = await session.get(CsvProfile, profile_id)
         if profile is None:
-            raise HTTPException(
-                status_code=404, detail=f"CSV profile {profile_id} not found"
-            )
+            raise NotFoundError(f"CSV profile {profile_id} not found")
         profile_delimiter = profile.delimiter
         profile_date_format = profile.date_format
         profile_decimal_comma = profile.decimal_comma
@@ -137,12 +136,12 @@ async def _run_import(
             row_filters=row_filters,
             row_exclude_filters=row_exclude_filters,
         )
-    except ValueError as e:
-        msg = str(e)
-        logger.warning("CSV import rejected: account_id=%d, reason=%s", account_id, msg)
-        if "not found" in msg:
-            raise HTTPException(status_code=404, detail=msg) from e
-        raise HTTPException(status_code=400, detail=msg) from e
+    except ServiceError as e:
+        # Central handler maps this to its status code; log the account context.
+        logger.warning(
+            "CSV import rejected: account_id=%d, reason=%s", account_id, e.detail
+        )
+        raise
 
     if result.created > 0:
         try:

--- a/api/my_private_finances/api/routes/ml.py
+++ b/api/my_private_finances/api/routes/ml.py
@@ -1,29 +1,19 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from my_private_finances.deps import SessionDep
 from my_private_finances.schemas.ml import Suggestion, TrainResult
-from my_private_finances.services.ml_categorization import (
-    ColdStartError,
-    suggest,
-    train,
-)
+from my_private_finances.services.ml_categorization import suggest, train
 
 router = APIRouter(prefix="/ml", tags=["ml"])
 
 
 @router.post("/train", response_model=TrainResult)
 async def train_model(session: SessionDep) -> TrainResult:
-    try:
-        return await train(session)
-    except ColdStartError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    return await train(session)
 
 
 @router.get("/suggest", response_model=list[Suggestion])
 async def get_suggestions(session: SessionDep) -> list[Suggestion]:
-    try:
-        return await suggest(session)
-    except ColdStartError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    return await suggest(session)

--- a/api/my_private_finances/main.py
+++ b/api/my_private_finances/main.py
@@ -15,7 +15,7 @@ from my_private_finances.config import Settings, get_settings
 from my_private_finances.db import create_engine, create_session_factory
 from my_private_finances.logging_config import setup_logging
 from my_private_finances.models.watch_folder_config import WatchSettings
-from my_private_finances.services.reporting import ReportError
+from my_private_finances.services.exceptions import ServiceError
 from my_private_finances.services.watch_folder import watch_folder_task
 
 setup_logging()
@@ -65,9 +65,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app = FastAPI(title="My Private Finances", lifespan=_lifespan)
 
-    @app.exception_handler(ReportError)
-    async def _report_error_handler(request: Request, exc: ReportError) -> JSONResponse:
-        return JSONResponse(status_code=exc.status_code, content={"detail": str(exc)})
+    @app.exception_handler(ServiceError)
+    async def _service_error_handler(
+        request: Request, exc: ServiceError
+    ) -> JSONResponse:
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
     engine: AsyncEngine = create_engine(settings.resolved_database_url)
     session_factory: async_sessionmaker[AsyncSession] = create_session_factory(engine)

--- a/api/my_private_finances/services/csv_import.py
+++ b/api/my_private_finances/services/csv_import.py
@@ -17,6 +17,7 @@ from my_private_finances.services.categorization import (
     load_rules_ordered,
     match_transaction,
 )
+from my_private_finances.services.exceptions import CsvFormatError, NotFoundError
 from my_private_finances.services.transaction_hash import HashInput, compute_import_hash
 
 logger = logging.getLogger(__name__)
@@ -135,7 +136,7 @@ async def import_transactions_from_csv_path(
     col: ColumnMap = {**DEFAULT_COLUMN_MAP, **(column_map or {})}
     res = await session.execute(select(Account).where(Account.id == account_id))  # type: ignore[arg-type]
     if res.scalar_one_or_none() is None:
-        raise ValueError(f"Account {account_id} not found")
+        raise NotFoundError(f"Account {account_id} not found")
 
     rules = await load_rules_ordered(session)
     logger.info(
@@ -164,7 +165,7 @@ async def import_transactions_from_csv_path(
         except UnicodeDecodeError:
             continue
     if text is None:
-        raise ValueError(
+        raise CsvFormatError(
             f"Cannot decode CSV file — tried {', '.join(_ENCODINGS)}. "
             "Please re-export with UTF-8 encoding."
         )
@@ -187,12 +188,12 @@ async def import_transactions_from_csv_path(
     with io.StringIO(text) as f:
         reader = csv.DictReader(f, delimiter=delimiter)
         if reader.fieldnames is None:
-            raise ValueError("CSV has no header row")
+            raise CsvFormatError("CSV has no header row")
 
         for idx, row in enumerate(reader, start=2):
             total_rows += 1
             if total_rows > max_rows:
-                raise ValueError(
+                raise CsvFormatError(
                     f"CSV exceeds the {max_rows:,}-row import limit; "
                     "split the file and import in parts"
                 )

--- a/api/my_private_finances/services/exceptions.py
+++ b/api/my_private_finances/services/exceptions.py
@@ -1,0 +1,51 @@
+"""Domain exceptions raised by the services layer (review finding C5 / issue #107).
+
+Services raise these instead of ``fastapi.HTTPException`` or bare ``ValueError``.
+Routes let them propagate; the single handler registered in
+``main.create_app`` turns ``status_code`` into the HTTP response. This removes
+the per-route ``raise HTTPException(...)`` translation and the
+``if "not found" in str(e)`` message-substring branching in ``routes/imports.py``.
+"""
+
+from __future__ import annotations
+
+
+class ServiceError(Exception):
+    """Base class for expected, client-facing service errors.
+
+    ``status_code`` / ``default_detail`` are class attributes so subclasses just
+    override them. ``detail`` is what the handler puts in the JSON body.
+    """
+
+    status_code = 400
+    default_detail = "Request could not be processed"
+
+    def __init__(self, detail: str | None = None) -> None:
+        self.detail = detail or self.default_detail
+        super().__init__(self.detail)
+
+
+class NotFoundError(ServiceError):
+    status_code = 404
+    default_detail = "Resource not found"
+
+
+class ValidationError(ServiceError):
+    status_code = 422
+    default_detail = "Invalid input"
+
+
+class ConflictError(ServiceError):
+    status_code = 409
+    default_detail = "Conflicting state"
+
+
+class CsvFormatError(ServiceError):
+    """The uploaded CSV can't be parsed at all (bad header, encoding, row cap).
+
+    400 rather than 422: the file — not the request shape — is malformed, and
+    this preserves the status code the import endpoint returned before #107.
+    """
+
+    status_code = 400
+    default_detail = "CSV file could not be parsed"

--- a/api/my_private_finances/services/ml_categorization.py
+++ b/api/my_private_finances/services/ml_categorization.py
@@ -16,14 +16,18 @@ from sqlmodel import select
 from my_private_finances.config import get_settings
 from my_private_finances.models import Category, Transaction
 from my_private_finances.schemas.ml import Suggestion, TrainResult
+from my_private_finances.services.exceptions import ServiceError
 
 logger = logging.getLogger(__name__)
 
 MIN_SAMPLES = 10
 
 
-class ColdStartError(Exception):
-    """Raised when there are not enough categorized transactions to train."""
+class ColdStartError(ServiceError):
+    """Not enough categorized transactions to train / no model trained yet."""
+
+    status_code = 400
+    default_detail = "Not enough categorized transactions to train a model"
 
 
 def _model_path() -> Path:

--- a/api/my_private_finances/services/reporting.py
+++ b/api/my_private_finances/services/reporting.py
@@ -35,6 +35,7 @@ from my_private_finances.schemas import (
     SpendingTrendReport,
     TopSpending,
 )
+from my_private_finances.services.exceptions import NotFoundError, ValidationError
 from my_private_finances.utils.money import money_from_db
 
 _ZERO = Decimal("0")
@@ -42,18 +43,12 @@ _CENTS = Decimal("0.01")
 _HUNDRED = Decimal("100")
 
 
-class ReportError(Exception):
-    """Base class for reporting input errors; carries an HTTP status code."""
-
-    status_code = 400
+class InvalidMonth(ValidationError):
+    """The ``month`` query parameter isn't a valid ``YYYY-MM`` value."""
 
 
-class InvalidMonth(ReportError):
-    status_code = 422
-
-
-class AccountNotFound(ReportError):
-    status_code = 404
+class AccountNotFound(NotFoundError):
+    """The requested ``account_id`` doesn't exist."""
 
 
 # --------------------------------------------------------------------------- #

--- a/api/tests/test_csv_import.py
+++ b/api/tests/test_csv_import.py
@@ -9,6 +9,7 @@ from my_private_finances.services.csv_import import (
     ColumnMap,
     import_transactions_from_csv_path,
 )
+from my_private_finances.services.exceptions import CsvFormatError, NotFoundError
 from tests.helpers import create_account, create_category, create_rule
 
 
@@ -147,7 +148,7 @@ async def test_csv_import_account_not_found_raises(
 
     session_factory = test_app._transport.app.state.session_factory  # type: ignore[attr-defined]
     async with session_factory() as session:
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(NotFoundError, match="not found"):
             await import_transactions_from_csv_path(
                 session=session,
                 account_id=99999,
@@ -222,7 +223,7 @@ async def test_csv_import_cannot_decode_raises(
 
     session_factory = test_app._transport.app.state.session_factory  # type: ignore[attr-defined]
     async with session_factory() as session:
-        with pytest.raises(ValueError, match="Cannot decode"):
+        with pytest.raises(CsvFormatError, match="Cannot decode"):
             await import_transactions_from_csv_path(
                 session=session,
                 account_id=acc["id"],
@@ -272,7 +273,7 @@ async def test_csv_import_no_header_row_raises(
 
     session_factory = test_app._transport.app.state.session_factory  # type: ignore[attr-defined]
     async with session_factory() as session:
-        with pytest.raises(ValueError, match="no header"):
+        with pytest.raises(CsvFormatError, match="no header"):
             await import_transactions_from_csv_path(
                 session=session,
                 account_id=acc["id"],

--- a/api/tests/test_import_limits.py
+++ b/api/tests/test_import_limits.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import AsyncClient
 
 from my_private_finances.services.csv_import import import_transactions_from_csv_path
+from my_private_finances.services.exceptions import CsvFormatError
 from tests.helpers import create_account
 
 
@@ -41,7 +42,7 @@ async def test_row_count_over_limit_raises_before_any_write(
 
     session_factory = test_app._transport.app.state.session_factory  # type: ignore[attr-defined]
     async with session_factory() as session:
-        with pytest.raises(ValueError, match="row"):
+        with pytest.raises(CsvFormatError, match="row"):
             await import_transactions_from_csv_path(
                 session=session,
                 account_id=acc["id"],

--- a/api/tests/test_service_exceptions.py
+++ b/api/tests/test_service_exceptions.py
@@ -1,0 +1,50 @@
+"""Service exception hierarchy + central HTTP mapping (issue #107 / C5).
+
+End-to-end mapping is covered by the endpoint tests (a bad ``month`` -> 422 in
+``test_reports_monthly``, a missing account -> 404 in ``test_import_endpoint``,
+cold-start -> 400 in ``test_ml_routes``). This file pins the contract those
+rely on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from my_private_finances.services.exceptions import (
+    ConflictError,
+    CsvFormatError,
+    NotFoundError,
+    ServiceError,
+    ValidationError,
+)
+from my_private_finances.services.ml_categorization import ColdStartError
+from my_private_finances.services.reporting import AccountNotFound, InvalidMonth
+
+
+@pytest.mark.parametrize(
+    ("exc", "status_code"),
+    [
+        (ServiceError(), 400),
+        (NotFoundError(), 404),
+        (ValidationError(), 422),
+        (ConflictError(), 409),
+        (CsvFormatError(), 400),
+        (ColdStartError(), 400),
+        (AccountNotFound(), 404),
+        (InvalidMonth(), 422),
+    ],
+)
+def test_status_codes(exc: ServiceError, status_code: int) -> None:
+    assert exc.status_code == status_code
+    assert isinstance(exc, ServiceError)
+
+
+def test_detail_defaults_and_override() -> None:
+    assert NotFoundError().detail == NotFoundError.default_detail
+    assert NotFoundError("Account 7 not found").detail == "Account 7 not found"
+    assert str(NotFoundError("boom")) == "boom"
+
+
+def test_reporting_errors_extend_the_shared_hierarchy() -> None:
+    assert issubclass(InvalidMonth, ValidationError)
+    assert issubclass(AccountNotFound, NotFoundError)


### PR DESCRIPTION
Closes #107 (finding C5).

## What

`routes/imports.py` decided HTTP status from `if "not found" in str(e)`, and
services raised a mix of `fastapi.HTTPException` (wrong layer) and bare
`ValueError`.

- **`services/exceptions.py`** — `ServiceError` base (`status_code` + `detail`)
  with `NotFoundError` (404), `ValidationError` (422), `ConflictError` (409),
  `CsvFormatError` (400).
- **`main.create_app`** registers one `@app.exception_handler(ServiceError)`
  → `{"detail": …}` with `exc.status_code`. Supersedes the report-only
  `ReportError` handler added in #104.
- `reporting.InvalidMonth` / `AccountNotFound` now extend
  `ValidationError` / `NotFoundError` (names unchanged for callers/tests);
  `ReportError` deleted.
- `ml_categorization.ColdStartError` → `ServiceError` (400); `routes/ml.py`
  drops its `try/except → HTTPException`.
- `csv_import` raises `NotFoundError` / `CsvFormatError` for the errors that
  propagate. Per-row parse errors that are caught and recorded stay
  `ValueError` (they never reach a client).
- `routes/imports.py` — **no more substring branching**; catches `ServiceError`
  only to log the account context, then re-raises.

## Status codes: unchanged

404 missing account / profile · 400 bad CSV / cold-start · 422 bad month.
`CsvFormatError` is deliberately 400 (not 422) to preserve the import
endpoint's existing contract — noted as a candidate follow-up.

## Verification

- `ruff check` + `ruff format --check` clean
- `mypy my_private_finances` — Success (73 files)
- `pytest` — 284 passed (new `test_service_exceptions.py`); coverage 83%
- `alembic check` — no drift

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm