### PR TITLE
feat(api): created_at / updated_at audit columns (#110)

### DIFF
--- a/api/alembic/versions/73cfdb5307bb_add_audit_timestamp_columns.py
+++ b/api/alembic/versions/73cfdb5307bb_add_audit_timestamp_columns.py
@@ -1,0 +1,61 @@
+"""add audit timestamp columns
+
+Revision ID: 73cfdb5307bb
+Revises: 2c39994ff739
+Create Date: 2026-09-08 20:03:06.575211
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "73cfdb5307bb"
+down_revision: Union[str, Sequence[str], None] = "2c39994ff739"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLES = (
+    "account",
+    "budget",
+    "categorization_rule",
+    "category",
+    "csv_profile",
+    "recurring_pattern",
+    "transaction",
+)
+
+
+def upgrade() -> None:
+    # SQLite rejects `ADD COLUMN ... DEFAULT CURRENT_TIMESTAMP NOT NULL` on a
+    # populated table ("non-constant default"), so recreate each table via
+    # batch mode — the CREATE TABLE default is allowed and backfills existing
+    # rows to now().
+    for table in _TABLES:
+        with op.batch_alter_table(table) as batch:
+            batch.add_column(
+                sa.Column(
+                    "created_at",
+                    sa.DateTime(),
+                    server_default=sa.text("(CURRENT_TIMESTAMP)"),
+                    nullable=False,
+                )
+            )
+            batch.add_column(
+                sa.Column(
+                    "updated_at",
+                    sa.DateTime(),
+                    server_default=sa.text("(CURRENT_TIMESTAMP)"),
+                    nullable=False,
+                )
+            )
+
+
+def downgrade() -> None:
+    for table in reversed(_TABLES):
+        with op.batch_alter_table(table) as batch:
+            batch.drop_column("updated_at")
+            batch.drop_column("created_at")

--- a/api/my_private_finances/models/account.py
+++ b/api/my_private_finances/models/account.py
@@ -5,10 +5,12 @@ from decimal import Decimal
 from typing import Optional
 
 from sqlalchemy import Column, Date, Numeric, String
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field
+
+from my_private_finances.models.mixins import TimestampMixin
 
 
-class Account(SQLModel, table=True):
+class Account(TimestampMixin, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(sa_column=Column(String(120), nullable=False))
     currency: str = Field(default="EUR", sa_column=Column(String(3), nullable=False))

--- a/api/my_private_finances/models/budget.py
+++ b/api/my_private_finances/models/budget.py
@@ -6,13 +6,15 @@ from typing import Optional
 from sqlalchemy import Column, Numeric, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
+from my_private_finances.models.mixins import TimestampMixin
+
 
 class BudgetBase(SQLModel):
     category_id: int = Field(foreign_key="category.id")
     amount: Decimal = Field(sa_column=Column(Numeric(12, 2), nullable=False))
 
 
-class Budget(BudgetBase, table=True):
+class Budget(TimestampMixin, BudgetBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
 
     __table_args__ = (UniqueConstraint("category_id"),)

--- a/api/my_private_finances/models/categorization_rule.py
+++ b/api/my_private_finances/models/categorization_rule.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from typing import Optional
 
 from sqlalchemy import Column, Integer, String
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field
+
+from my_private_finances.models.mixins import TimestampMixin
 
 
-class CategorizationRule(SQLModel, table=True):
+class CategorizationRule(TimestampMixin, table=True):
     __tablename__ = "categorization_rule"
 
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/api/my_private_finances/models/category.py
+++ b/api/my_private_finances/models/category.py
@@ -5,6 +5,8 @@ from typing import Optional
 from sqlalchemy import Column, String
 from sqlmodel import Field, SQLModel
 
+from my_private_finances.models.mixins import TimestampMixin
+
 
 class CategoryBase(SQLModel):
     name: str = Field(sa_column=Column(String(120), nullable=False, index=True))
@@ -14,5 +16,5 @@ class CategoryBase(SQLModel):
     )
 
 
-class Category(CategoryBase, table=True):
+class Category(TimestampMixin, CategoryBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/api/my_private_finances/models/csv_profile.py
+++ b/api/my_private_finances/models/csv_profile.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from sqlalchemy import JSON, Column, String
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field
+
+from my_private_finances.models.mixins import TimestampMixin
 
 
-class CsvProfile(SQLModel, table=True):
+class CsvProfile(TimestampMixin, table=True):
     __tablename__ = "csv_profile"
 
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/api/my_private_finances/models/mixins.py
+++ b/api/my_private_finances/models/mixins.py
@@ -1,0 +1,34 @@
+"""Shared model mixins (review finding C15 / issue #110)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import func
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class TimestampMixin(SQLModel):
+    """Adds server-managed ``created_at`` / ``updated_at`` audit columns.
+
+    ``server_default`` / ``onupdate`` keep the values correct for raw SQL and
+    migrations; ``default_factory`` populates them on ORM-created rows before a
+    refresh. ``sa_column_kwargs`` (not ``sa_column``) so SQLModel generates a
+    distinct Column per table.
+    """
+
+    created_at: datetime = Field(
+        default_factory=_utcnow,
+        sa_column_kwargs={"server_default": func.now()},
+    )
+    updated_at: datetime = Field(
+        default_factory=_utcnow,
+        # onupdate is a Python callable (not func.now()) so ORM inserts and
+        # updates use the same clock/precision as created_at; server_default
+        # is the safety net for rows touched by raw SQL / migrations.
+        sa_column_kwargs={"server_default": func.now(), "onupdate": _utcnow},
+    )

--- a/api/my_private_finances/models/recurring_pattern.py
+++ b/api/my_private_finances/models/recurring_pattern.py
@@ -7,6 +7,8 @@ from typing import Optional
 from sqlalchemy import Column, Date, Numeric, String, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
+from my_private_finances.models.mixins import TimestampMixin
+
 
 class RecurringPatternBase(SQLModel):
     account_id: int = Field(foreign_key="account.id", index=True)
@@ -21,7 +23,7 @@ class RecurringPatternBase(SQLModel):
     category_id: Optional[int] = Field(default=None, foreign_key="category.id")
 
 
-class RecurringPattern(RecurringPatternBase, table=True):
+class RecurringPattern(TimestampMixin, RecurringPatternBase, table=True):
     __tablename__ = "recurring_pattern"
 
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/api/my_private_finances/models/transaction.py
+++ b/api/my_private_finances/models/transaction.py
@@ -7,6 +7,8 @@ from typing import Optional
 from sqlalchemy import Column, Date, Index, Numeric, String, Text, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
+from my_private_finances.models.mixins import TimestampMixin
+
 
 class TransactionBase(SQLModel):
     account_id: int = Field(foreign_key="account.id", index=True)
@@ -28,7 +30,7 @@ class TransactionBase(SQLModel):
     import_hash: str = Field(sa_column=Column(String(64), nullable=False))
 
 
-class Transaction(TransactionBase, table=True):
+class Transaction(TimestampMixin, TransactionBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     is_transfer: bool = Field(default=False)
 

--- a/api/my_private_finances/schemas/transaction_read.py
+++ b/api/my_private_finances/schemas/transaction_read.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional
 
@@ -24,6 +24,8 @@ class TransactionRead(ReadSchema):
     import_source: Optional[str] = None
     import_hash: str
     is_transfer: bool = False
+
+    created_at: Optional[datetime] = None
 
     @field_serializer("amount")
     def _serialize_amount(self, value: Decimal) -> str:

--- a/api/tests/test_audit_timestamps.py
+++ b/api/tests/test_audit_timestamps.py
@@ -1,0 +1,41 @@
+"""created_at / updated_at audit columns (issue #110 / C15)."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from my_private_finances.models import Account
+from tests.helpers import create_account, create_transaction
+
+
+@pytest.mark.asyncio
+async def test_timestamps_set_on_insert_and_bump_on_update(
+    db_session: AsyncSession,
+) -> None:
+    acc = Account(name="Main", currency="EUR")
+    db_session.add(acc)
+    await db_session.commit()
+    await db_session.refresh(acc)
+
+    assert acc.created_at is not None
+    assert acc.updated_at is not None
+    first_updated = acc.updated_at
+
+    acc.name = "Renamed"
+    await db_session.commit()
+    await db_session.refresh(acc)
+
+    assert acc.updated_at >= first_updated
+    assert acc.created_at <= acc.updated_at
+
+
+@pytest.mark.asyncio
+async def test_transaction_read_exposes_created_at(test_app: AsyncClient) -> None:
+    acc = await create_account(test_app)
+    tx = await create_transaction(test_app, account_id=acc["id"], external_id="ts-1")
+    assert tx["created_at"] is not None
+
+    listed = await test_app.get("/api/transactions", params={"account_id": acc["id"]})
+    assert listed.json()["items"][0]["created_at"] is not None


### PR DESCRIPTION
Closes #110 (finding C15).

## What

- **`models/mixins.py::TimestampMixin`** — `created_at` / `updated_at`.
  `default_factory=_utcnow` + `server_default=func.now()`; `updated_at` also
  `onupdate=_utcnow` (a Python callable, so ORM inserts and updates use one
  clock/precision; `server_default` is the safety net for raw SQL / migrations).
  Uses `sa_column_kwargs` — not `sa_column` — so SQLModel builds a distinct
  Column per table.
- Mixed into **Account, Budget, CategorizationRule, Category, CsvProfile,
  RecurringPattern, Transaction**.
- **Migration `73cfdb5307bb`** — adds both columns `NOT NULL` to all 7 tables
  via **SQLite batch mode** (table recreate). A plain
  `ADD COLUMN … DEFAULT CURRENT_TIMESTAMP NOT NULL` is rejected on a populated
  SQLite table ("non-constant default"); the recreate path backfills existing
  rows to `now()`. Verified up + down + backfill on a seeded DB.
- **`TransactionRead`** now returns `created_at`.

## Verification

- `alembic check` — no drift; upgrade/downgrade/backfill tested manually
- `ruff` + `mypy` clean
- `pytest` — all pass; new `tests/test_audit_timestamps.py`
- coverage 82%

Independent of the other open PRs (own migration; `down_revision` = current
head `2c39994ff739`). If another migration merges first, this needs a
`down_revision` bump.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm