### PR TITLE
feat(api): watcher supervision, /health, destructive guard + CORS (#114, #99)

### DIFF
--- a/api/my_private_finances/api/router.py
+++ b/api/my_private_finances/api/router.py
@@ -13,6 +13,7 @@ from my_private_finances.api.routes.data_management import (
     router as data_management_router,
 )
 from my_private_finances.api.routes.export import router as export_router
+from my_private_finances.api.routes.health import router as health_router
 from my_private_finances.api.routes.imports import router as imports_router
 from my_private_finances.api.routes.ml import router as ml_router
 from my_private_finances.api.routes.net_worth import router as net_worth_router
@@ -42,3 +43,4 @@ api_router.include_router(export_router)
 api_router.include_router(data_management_router)
 api_router.include_router(ml_router)
 api_router.include_router(watch_folder_router)
+api_router.include_router(health_router)

--- a/api/my_private_finances/api/routes/data_management.py
+++ b/api/my_private_finances/api/routes/data_management.py
@@ -13,7 +13,7 @@ from fastapi.concurrency import run_in_threadpool
 from sqlalchemy import delete, func, select
 
 from my_private_finances.db import sqlite_path_from_engine
-from my_private_finances.deps import SessionDep
+from my_private_finances.deps import RequireConfirmation, SessionDep
 from my_private_finances.models import (
     Account,
     Budget,
@@ -98,7 +98,7 @@ def _sqlite_copy(src_path: str, dst_path: str) -> None:
         src.close()
 
 
-@router.post("/restore/sqlite", status_code=200)
+@router.post("/restore/sqlite", status_code=200, dependencies=[RequireConfirmation])
 async def restore_sqlite(file: UploadFile, request: Request) -> dict:
     data = await file.read()
     if len(data) > _MAX_RESTORE_BYTES:
@@ -137,7 +137,9 @@ async def _count(session: SessionDep, model: type) -> int:
     return int(result.scalar_one())
 
 
-@router.delete("/data/transactions", status_code=200)
+@router.delete(
+    "/data/transactions", status_code=200, dependencies=[RequireConfirmation]
+)
 async def delete_transactions(session: SessionDep) -> dict:
     """Delete all transactions, transfer candidates, and recurring patterns."""
     models = [TransferCandidate, RecurringPattern, Transaction]
@@ -149,7 +151,7 @@ async def delete_transactions(session: SessionDep) -> dict:
     return {"deleted": deleted}
 
 
-@router.delete("/data", status_code=200)
+@router.delete("/data", status_code=200, dependencies=[RequireConfirmation])
 async def wipe_all_data(session: SessionDep) -> dict:
     """Delete all data from all tables in FK-safe order."""
     models = [

--- a/api/my_private_finances/api/routes/health.py
+++ b/api/my_private_finances/api/routes/health.py
@@ -1,8 +1,24 @@
-from fastapi import APIRouter
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from my_private_finances.services.watch_folder import WatcherStatus
 
 router = APIRouter(tags=["health"])
 
 
 @router.get("/health")
-async def health():
-    return {"status": "ok"}
+async def health(request: Request) -> dict[str, Any]:
+    status: WatcherStatus | None = getattr(request.app.state, "watcher_status", None)
+    watcher: dict[str, Any] | None = None
+    if status is not None:
+        watcher = {
+            "running": status.running,
+            "last_error": status.last_error,
+            "restarts": status.restarts,
+            "files_processed": status.files_processed,
+            "root_path": status.root_path,
+        }
+    return {"status": "ok", "watcher": watcher}

--- a/api/my_private_finances/config.py
+++ b/api/my_private_finances/config.py
@@ -21,6 +21,13 @@ class Settings(BaseSettings):
     database_url: str | None = None
     log_level: str = "INFO"
 
+    # Browser origins allowed to call the API. Localhost-only by default; the
+    # PWA/LAN roadmap (feature 130) must widen this *and* add auth (see #99).
+    cors_origins: list[str] = [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+
     @property
     def sqlite_path(self) -> Path:
         return self.data_dir / "my_private_finances.sqlite"

--- a/api/my_private_finances/db.py
+++ b/api/my_private_finances/db.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from sqlalchemy import event
@@ -61,10 +60,3 @@ def sqlite_path_from_engine(engine: AsyncEngine) -> Path:
     if not url.database or url.database == ":memory:":
         raise ValueError("SQLite engine is not backed by a file")
     return Path(url.database)
-
-
-async def get_session(
-    session_factory: async_sessionmaker[AsyncSession],
-) -> AsyncGenerator[AsyncSession, None]:
-    async with session_factory() as session:
-        yield session

--- a/api/my_private_finances/deps.py
+++ b/api/my_private_finances/deps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from typing import Annotated
 
-from fastapi import Depends, Request
+from fastapi import Depends, Header, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -14,3 +14,23 @@ async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
 
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
+
+
+async def require_confirmation(
+    x_requested_with: Annotated[str | None, Header()] = None,
+) -> None:
+    """Guard for destructive / restore endpoints (SEC2).
+
+    A cross-origin *simple* request can't set a custom header without a CORS
+    preflight, which the origin allow-list rejects for unknown origins — so
+    requiring ``X-Requested-With`` blocks a CSRF-shaped cross-site POST while
+    staying a no-op for the SPA (its fetch wrapper always sends it).
+    """
+    if not x_requested_with:
+        raise HTTPException(
+            status_code=403,
+            detail="This endpoint requires an 'X-Requested-With' header",
+        )
+
+
+RequireConfirmation = Depends(require_confirmation)

--- a/api/my_private_finances/main.py
+++ b/api/my_private_finances/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
@@ -16,7 +17,10 @@ from my_private_finances.db import create_engine, create_session_factory
 from my_private_finances.logging_config import setup_logging
 from my_private_finances.models.watch_folder_config import WatchSettings
 from my_private_finances.services.exceptions import ServiceError
-from my_private_finances.services.watch_folder import watch_folder_task
+from my_private_finances.services.watch_folder import (
+    WatcherStatus,
+    watch_folder_supervisor,
+)
 
 setup_logging()
 
@@ -41,9 +45,12 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             "Could not read watch settings from DB, using default", exc_info=True
         )
 
-    task = asyncio.create_task(watch_folder_task(session_factory, root_path))
+    status: WatcherStatus = app.state.watcher_status
+    task = asyncio.create_task(
+        watch_folder_supervisor(session_factory, root_path, status)
+    )
     app.state.watcher_task = task
-    logger.info("Watch folder task started")
+    logger.info("Watch folder supervisor started")
 
     yield
 
@@ -65,6 +72,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app = FastAPI(title="My Private Finances", lifespan=_lifespan)
 
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
     @app.exception_handler(ServiceError)
     async def _service_error_handler(
         request: Request, exc: ServiceError
@@ -79,6 +94,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.state.session_factory = session_factory
     app.state.db_path = settings.sqlite_path
     app.state.restore_lock = asyncio.Lock()
+    app.state.watcher_status = WatcherStatus()
     app.include_router(api_router, prefix="/api")
 
     return app

--- a/api/my_private_finances/services/watch_folder.py
+++ b/api/my_private_finances/services/watch_folder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
@@ -19,6 +20,17 @@ from my_private_finances.services.csv_import import import_transactions_from_csv
 from my_private_finances.services.recurring_detection import run_detection
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WatcherStatus:
+    """Live status of the watch-folder background task (exposed by /health)."""
+
+    running: bool = False
+    last_error: str | None = None
+    restarts: int = 0
+    files_processed: int = 0
+    root_path: str | None = None
 
 
 class _QueueHandler(FileSystemEventHandler):
@@ -142,6 +154,7 @@ def _move_to_failed(path: Path, failed_dir: Path, error: str) -> None:
 async def watch_folder_task(
     session_factory: async_sessionmaker[AsyncSession],
     watch_path: Path,
+    status: WatcherStatus | None = None,
 ) -> None:
     """Long-running asyncio task that watches *watch_path* and auto-imports files."""
     watch_path.mkdir(parents=True, exist_ok=True)
@@ -161,8 +174,50 @@ async def watch_folder_task(
             if not path.exists():
                 continue
             await _process_file(path, session_factory)
+            if status is not None:
+                status.files_processed += 1
     except asyncio.CancelledError:
         logger.info("Watch folder task cancelled, stopping observer")
         observer.stop()
         observer.join()
         raise
+    except BaseException:
+        observer.stop()
+        observer.join()
+        raise
+
+
+async def watch_folder_supervisor(
+    session_factory: async_sessionmaker[AsyncSession],
+    watch_path: Path,
+    status: WatcherStatus,
+    *,
+    max_backoff: float = 60.0,
+) -> None:
+    """Run :func:`watch_folder_task`, relaunching it after an unexpected crash
+    with exponential backoff (A7). Cancellation stops the supervisor.
+    """
+    status.root_path = str(watch_path)
+    backoff = min(1.0, max_backoff)
+    while True:
+        try:
+            status.running = True
+            await watch_folder_task(session_factory, watch_path, status)
+            status.running = False
+            logger.info("watch_folder_task returned; supervisor stopping")
+            return
+        except asyncio.CancelledError:
+            status.running = False
+            raise
+        except Exception as exc:
+            status.running = False
+            status.last_error = repr(exc)
+            status.restarts += 1
+            logger.error(
+                "watch_folder_task crashed (restart #%d), retrying in %.0fs",
+                status.restarts,
+                backoff,
+                exc_info=True,
+            )
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, max_backoff)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -36,7 +36,13 @@ async def test_app() -> AsyncGenerator[AsyncClient, None]:
                 await conn.run_sync(SQLModel.metadata.create_all)
 
         transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # The SPA's fetch wrapper always sends X-Requested-With; mirror that so
+        # the destructive-endpoint guard (#99) is transparent to normal tests.
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        ) as client:
             yield client
 
         await engine.dispose()

--- a/api/tests/test_health_and_guard.py
+++ b/api/tests/test_health_and_guard.py
@@ -1,0 +1,96 @@
+"""/health endpoint + destructive-endpoint confirmation guard (#114, #99)."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import SQLModel
+
+from my_private_finances.config import Settings
+from my_private_finances.main import create_app
+from my_private_finances.services.watch_folder import (
+    WatcherStatus,
+    watch_folder_supervisor,
+)
+
+
+@pytest.mark.asyncio
+async def test_health_reports_watcher_status(test_app: AsyncClient) -> None:
+    resp = await test_app.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert set(body["watcher"]) == {
+        "running",
+        "last_error",
+        "restarts",
+        "files_processed",
+        "root_path",
+    }
+
+
+@pytest.mark.asyncio
+async def test_destructive_endpoints_require_guard_header() -> None:
+    """A request without X-Requested-With is rejected with 403."""
+    with tempfile.TemporaryDirectory() as tmp:
+        settings = Settings(
+            data_dir=Path(tmp),
+            database_url=f"sqlite+aiosqlite:///{Path(tmp) / 'g.sqlite'}",
+        )
+        app = create_app(settings)
+        engine = app.state.engine
+        async with engine.connect() as conn:
+            async with conn.begin():
+                await conn.run_sync(SQLModel.metadata.create_all)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            for method, path in [
+                ("DELETE", "/api/data"),
+                ("DELETE", "/api/data/transactions"),
+            ]:
+                r = await bare.request(method, path)
+                assert r.status_code == 403, (method, path, r.text)
+
+            guarded = await bare.request(
+                "DELETE", "/api/data", headers={"X-Requested-With": "1"}
+            )
+            assert guarded.status_code == 200
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_supervisor_relaunches_after_crash() -> None:
+    status = WatcherStatus()
+    calls = 0
+
+    async def flaky(_sf: object, _path: Path, st: WatcherStatus) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("boom")
+        st.running = True
+        await asyncio.sleep(3600)
+
+    import my_private_finances.services.watch_folder as wf
+
+    orig = wf.watch_folder_task
+    wf.watch_folder_task = flaky  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(
+            watch_folder_supervisor(object(), Path("/tmp/x"), status, max_backoff=0.01)  # type: ignore[arg-type]
+        )
+        await asyncio.sleep(0.2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        wf.watch_folder_task = orig  # type: ignore[assignment]
+
+    assert calls >= 2
+    assert status.restarts >= 1
+    assert status.last_error is not None and "boom" in status.last_error

--- a/app/src/lib/api/client.ts
+++ b/app/src/lib/api/client.ts
@@ -9,9 +9,18 @@ export class ApiError extends Error {
   }
 }
 
+// Sent on every request. The backend's destructive endpoints require it (#99):
+// a cross-origin simple request can't set it without a CORS preflight, which
+// the origin allow-list blocks for unknown origins.
+const DEFAULT_HEADERS = {
+  Accept: "application/json",
+  "Content-Type": "application/json",
+  "X-Requested-With": "XMLHttpRequest",
+};
+
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(path, {
-    headers: { Accept: "application/json", "Content-Type": "application/json" },
+    headers: DEFAULT_HEADERS,
     ...init,
   });
   const body = await res.json().catch(() => null);
@@ -40,7 +49,10 @@ export async function apiPatch<T>(path: string, data: unknown): Promise<T> {
 }
 
 export async function apiDelete(path: string): Promise<void> {
-  const res = await fetch(path, { method: "DELETE" });
+  const res = await fetch(path, {
+    method: "DELETE",
+    headers: { "X-Requested-With": "XMLHttpRequest" },
+  });
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     throw new ApiError(res.status, body);

--- a/app/src/lib/api/settings.ts
+++ b/app/src/lib/api/settings.ts
@@ -4,7 +4,11 @@ export async function restoreSqlite(file: File): Promise<void> {
   const formData = new FormData();
   formData.append("file", file);
 
-  const res = await fetch("/api/restore/sqlite", { method: "POST", body: formData });
+  const res = await fetch("/api/restore/sqlite", {
+    method: "POST",
+    body: formData,
+    headers: { "X-Requested-With": "XMLHttpRequest" },
+  });
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     throw new ApiError(res.status, body);
@@ -12,7 +16,10 @@ export async function restoreSqlite(file: File): Promise<void> {
 }
 
 export async function deleteTransactions(): Promise<{ deleted: number }> {
-  const res = await fetch("/api/data/transactions", { method: "DELETE" });
+  const res = await fetch("/api/data/transactions", {
+    method: "DELETE",
+    headers: { "X-Requested-With": "XMLHttpRequest" },
+  });
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     throw new ApiError(res.status, body);
@@ -21,7 +28,10 @@ export async function deleteTransactions(): Promise<{ deleted: number }> {
 }
 
 export async function wipeAllData(): Promise<{ deleted: number }> {
-  const res = await fetch("/api/data", { method: "DELETE" });
+  const res = await fetch("/api/data", {
+    method: "DELETE",
+    headers: { "X-Requested-With": "XMLHttpRequest" },
+  });
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     throw new ApiError(res.status, body);


### PR DESCRIPTION
Closes #114 (A7, C10-health) and #99 (SEC2, SEC5-partial). Combined because both
edit `create_app` / `_lifespan`.

> Stacked on #140 (#107) — its commit shows here until #140 merges.

## #114 — watcher supervision + /health

- **`watch_folder_supervisor`** wraps `watch_folder_task`: on an unexpected
  crash it logs and relaunches with exponential backoff (cap 60s); cancellation
  stops it cleanly. `_lifespan` starts the supervisor instead of the raw task.
- **`WatcherStatus`** (`running` / `last_error` / `restarts` / `files_processed`
  / `root_path`) on `app.state.watcher_status`.
- **`GET /api/health`** — `routes/health.py` was never registered; now it is,
  and it reports the watcher status.
- Removed the dead `db.py::get_session`.

## #99 — confirmation guard + explicit CORS

- **`deps.require_confirmation`** — `X-Requested-With` header required on
  `POST /api/restore/sqlite`, `DELETE /api/data`, `DELETE /api/data/transactions`
  → **403** without it. A cross-origin *simple* request can't set that header
  without a CORS preflight, which the origin allow-list rejects for unknown
  origins, so a CSRF-shaped cross-site POST is blocked.
- **`CORSMiddleware`** with `settings.cors_origins` (default
  `localhost:5173` + `127.0.0.1:5173`) — explicit allow-list, not the default.
- **Frontend**: `lib/api/client.ts` sends `X-Requested-With` on every request;
  the three raw fetches in `lib/api/settings.ts` send it too.

## Verification

- `ruff` + `mypy` clean; `pytest` 291 pass (`tests/test_health_and_guard.py`)
- `alembic check` — no drift
- frontend `tsc --noEmit` + `eslint` clean (frontend unit tests run on CI —
  Node 24)

Follow-up left for SECURITY.md / ADR: **#115**.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm