### PR TITLE
docs: explicit security model + ADR 0006 for bare-int FKs (#115)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,8 +46,57 @@ Do not open a public GitHub issue for security-sensitive reports.
 
 ***
 
-## Security Design Notes
-- "My Private Finances" is designed to minimize attack surface by operating locally
-- No user data is transmitted to external services by default
-- All dependencies are managed explicitly and audited via CI
-- Contributors are encouraged to keep security and privacy considerations in mind
+## Security Model
+
+The current design assumes a **single trusted user on a single trusted
+machine**. It is stated explicitly here so that changes which break the
+assumption are recognised as security-relevant.
+
+### What we rely on
+
+| Control | Where | What it assumes |
+|---|---|---|
+| **Loopback bind only** | the API is served on `127.0.0.1` (dev: Vite proxies `/api` to it; desktop: PyInstaller sidecar on localhost) | nothing else on the machine is hostile; no other local user is untrusted |
+| **No authentication — by design** | there is no login, session, or API key | the OS user account *is* the security boundary; anyone who can reach the socket is authorised |
+| **Explicit CORS allow-list** | `Settings.cors_origins` (default `localhost:5173` / `127.0.0.1:5173`) | the browser enforces same-origin / CORS rules; the SPA runs from an allowed origin |
+| **Confirmation header on destructive endpoints** | `X-Requested-With` required for `POST /api/restore/sqlite`, `DELETE /api/data`, `DELETE /api/data/transactions` (see [#99]) | a cross-site page cannot set a custom header on a *simple* request without a CORS preflight, which the allow-list rejects |
+| **SQLite foreign keys enforced** | `PRAGMA foreign_keys=ON` per connection | — |
+| **Local-only data flow** | no telemetry; no outbound requests except explicit CSV imports the user starts and dependency downloads at build time | the user does not paste a malicious file path / URL |
+| **Path-traversal guard** | watch-folder importer refuses files resolving outside the data root | — |
+
+### What breaks this model (do not do these without adding auth first)
+
+- **Binding to `0.0.0.0` or a LAN address.** Every endpoint becomes reachable
+  by anything on the network. There is no authentication to fall back on.
+- **Serving the SPA and API to a browser on another device** (the PWA / LAN
+  roadmap item, [feature 130](docs/product/130-pwa-lan-access.md)). This is
+  **gated on adding authentication** (at minimum a shared secret / token, more
+  likely per-device credentials) and on re-reviewing every state-changing
+  endpoint for CSRF.
+- **Adding a reverse proxy / tunnel** (ngrok, Cloudflare Tunnel, etc.) in front
+  of the API — same as binding publicly.
+- **Widening `cors_origins`** to `*` or to origins not under the user's
+  control.
+- **Running the process as a shared service account** on a multi-user host —
+  the "OS user is the boundary" assumption no longer holds.
+
+### Out of scope (accepted)
+
+- Encryption at rest of the SQLite file — it is the user's own disk.
+- Rate limiting / brute-force protection — there is nothing to brute-force.
+- Audit logging of reads — single-user.
+
+[#99]: https://github.com/gnuhannes/my-private-finances/issues/99
+
+***
+
+## Design Notes
+
+- Minimise attack surface by operating locally; no user data leaves the machine
+  by default.
+- Dependencies are pinned and audited in CI (`pip-licenses`, `npm audit` /
+  `pnpm audit`, Dependabot).
+- The data layer deliberately uses bare-integer foreign keys with no ORM
+  relationships — see [ADR 0006](docs/adr/0006-bare-integer-foreign-keys.md).
+- Contributors: keep the assumptions above in mind; a change that touches the
+  bind address, auth, CORS, or a destructive endpoint needs a note in the PR.

--- a/docs/adr/0006-bare-integer-foreign-keys.md
+++ b/docs/adr/0006-bare-integer-foreign-keys.md
@@ -1,0 +1,85 @@
+# ADR 0006: Bare integer foreign keys, no SQLModel `Relationship()`
+
+Date: 2026-09-08
+Status: Accepted
+
+***
+
+## Context
+
+Every model in `api/my_private_finances/models/` stores its foreign keys as
+plain integer columns:
+
+```python
+class Transaction(TransactionBase, table=True):
+    account_id: int = Field(foreign_key="account.id", index=True)
+    category_id: Optional[int] = Field(default=None, foreign_key="category.id")
+```
+
+There is no `Relationship()` anywhere — no `Transaction.account`,
+`Category.children`, `Budget.category`. Route and service code that needs a
+related row loads it explicitly (`await session.get(Account, tx.account_id)`),
+and joins in the reporting layer are written against model columns / the
+`services.reporting.table(Model).c.*` helper, not relationship attributes.
+
+The architecture review (2026-09-08, finding A4) flagged this as worth writing
+down: it is a deliberate choice with a real, recurring cost, and a new
+contributor will otherwise assume relationships were simply forgotten.
+
+## Decision
+
+**Keep foreign keys as bare integer columns. Do not add SQLModel /
+SQLAlchemy `Relationship()` attributes.**
+
+Related data is loaded explicitly where it is needed:
+
+- single parent → `await session.get(Model, fk_id)`
+- batch → `select(Model).where(Model.id.in_(ids))` then a dict lookup
+  (see `routes/transfers.py::_load_related`, `routes/budgets.py`)
+- aggregate joins → explicit `select(...).join(...)` /
+  `select_from(table(A).outerjoin(table(B), ...))` in `services/reporting.py`
+
+## Rationale
+
+1. **Async lazy-load is a foot-gun.** With an `AsyncSession`, touching an
+   unloaded relationship attribute (`tx.account.name`) raises
+   `MissingGreenlet` at runtime rather than lazy-loading. Avoiding it requires
+   remembering `selectinload` / `joinedload` on every query, and forgetting is
+   a production error, not a test failure. Bare FKs make the I/O explicit and
+   impossible to trigger by accident.
+2. **`expire_on_commit=False`** (our session config, needed so response
+   serialization can read attributes after `commit()`) interacts badly with
+   relationships — stale collections after a commit are easy to produce.
+3. **The object graph is shallow.** The deepest chain is
+   `Transaction → Category → parent Category`. The explicit-load boilerplate is
+   bounded and lives in a handful of `_load_related`-style helpers.
+4. **Queries stay legible.** Reporting SQL is already explicit Core-style
+   `select`s; relationships would not simplify them.
+5. **FKs are still enforced.** `PRAGMA foreign_keys=ON` is set per connection
+   (`db.py`), and `ON DELETE` semantics are being made explicit separately
+   (#117). Referential integrity does not depend on ORM relationships.
+
+## Consequences
+
+**Cost (accepted):**
+
+- Every "give me the related row" needs an explicit query. N+1 is possible if a
+  loop calls `session.get` per item — the mitigation is the batch-load helper
+  pattern, which must be used consciously.
+- No cascade-on-delete via the ORM `cascade=` option; delete ordering is
+  hand-written (`routes/data_management.py::wipe_all_data` deletes in FK-safe
+  order). #117 moves the cascade decision to the database.
+- Tooling that introspects relationships (some admin / GraphQL generators)
+  won't see them.
+
+**Benefit:**
+
+- No `MissingGreenlet` class of bug.
+- Data access is grep-able: every DB read is a visible `select` / `session.get`.
+- Models are plain data; no query-strategy decisions embedded in them.
+
+## Revisit if
+
+- The object graph deepens materially (3+ hops used across many call sites), or
+- We adopt a sync read-path (e.g. a reporting worker) where lazy-load is safe,
+  making selective `Relationship()` use low-risk.


### PR DESCRIPTION
Closes #115 (SEC5, SEC2-policy, A4). Docs only.

- **SECURITY.md** — new "Security Model" section:
  - a table of what the design relies on (loopback bind, no-auth-by-design,
    CORS allow-list, `X-Requested-With` guard, FK enforcement, local-only data
    flow, path-traversal guard) and *what each assumes*
  - a "what breaks this model" list — binding publicly, **feature 130 (PWA/LAN)
    gated on adding auth**, tunnels, widening CORS, shared service account
  - accepted out-of-scope (at-rest encryption, rate limiting, read audit)
- **ADR 0006** — bare integer foreign keys, no `Relationship()`: rationale
  (async lazy-load / `MissingGreenlet`, `expire_on_commit=False`, shallow
  graph), the explicit-load boilerplate cost, and revisit criteria.

No code changes.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm