### PR TITLE
feat(app): consolidate api client + frontend coverage floor (#113, #116)

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -32,8 +32,12 @@ typecheck:
 test:
 	pnpm run -s test
 
+.PHONY: test-cov
+test-cov:
+	pnpm run -s test:coverage
+
 .PHONY: ci
-ci: lint typecheck format-check test
+ci: lint typecheck format-check test-cov
 	@echo "✅ app checks passed"
 
 # E2E is deliberately not part of `ci` — it is heavier (boots the backend +

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,8 @@
     "e2e": "playwright test",
     "e2e:report": "playwright show-report",
     "format": "prettier . --write",
-    "format:check": "prettier . --check"
+    "format:check": "prettier . --check",
+    "test:coverage": "vitest run --coverage -c vitest.config.ts"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.102.8",
@@ -35,6 +36,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.7",
     "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^9.39.5",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@8.2.2(@types/node@26.5.0)(esbuild@0.27.2))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.11
+        version: 4.1.11(vitest@4.1.11)
       eslint:
         specifier: ^9.39.5
         version: 9.39.5
@@ -92,7 +95,7 @@ importers:
         version: 8.2.2(@types/node@26.5.0)(esbuild@0.27.2)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@26.5.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.27.2))
+        version: 4.1.11(@types/node@26.5.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.27.2))
 
 packages:
 
@@ -193,6 +196,10 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -764,6 +771,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/coverage-v8@4.1.11':
+    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.11
+      vitest: 4.1.11
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.11':
     resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
@@ -855,6 +871,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.6:
+    resolution: {integrity: sha512-fvpl29helSO2w/z7utIbrkNXILdrLwDwAMH2I/zPKlGf5244+gf+B4cyS1sANcrPY2h+hWCGSgC8N61s/+AF9A==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1364,6 +1383,9 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-parse-stringify@4.0.1:
     resolution: {integrity: sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==}
 
@@ -1515,6 +1537,21 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1651,6 +1688,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2427,6 +2471,8 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -2903,6 +2949,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.11(vitest@4.1.11)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.11
+      ast-v8-to-istanbul: 1.0.6
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.11(@types/node@26.5.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.27.2))
+
   '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3024,6 +3084,12 @@ snapshots:
       is-array-buffer: 3.0.5
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -3624,6 +3690,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-escaper@2.0.2: {}
+
   html-parse-stringify@4.0.1: {}
 
   i18next@25.10.10(typescript@5.9.3):
@@ -3771,6 +3839,21 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.3.2:
@@ -3892,6 +3975,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.6.0
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   math-intrinsics@1.1.0: {}
 
@@ -4452,7 +4545,7 @@ snapshots:
       esbuild: 0.27.2
       fsevents: 2.3.3
 
-  vitest@4.1.11(@types/node@26.5.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.27.2)):
+  vitest@4.1.11(@types/node@26.5.0)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.27.2)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.5.0)(esbuild@0.27.2))
@@ -4476,6 +4569,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.5.0
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
       jsdom: 30.0.1
     transitivePeerDependencies:
       - msw

--- a/app/src/components/CsvProfileManager.tsx
+++ b/app/src/components/CsvProfileManager.tsx
@@ -118,7 +118,7 @@ export function CsvProfileManager({ onClose }: Props) {
               <li key={p.id} className={styles.item}>
                 <span className={styles.itemName}>{p.name}</span>
                 <span className={styles.itemMeta}>
-                  {p.delimiter === "\t" ? "Tab" : p.delimiter} · {p.date_format}
+                  {p.delimiter === "\t" ? t("csvProfiles.delimTab") : p.delimiter} · {p.date_format}
                   {p.decimal_comma ? " · dec," : ""}
                 </span>
                 <div className={styles.itemActions}>
@@ -162,7 +162,7 @@ export function CsvProfileManager({ onClose }: Props) {
               >
                 <option value=",">,</option>
                 <option value=";">;</option>
-                <option value="&#9;">Tab</option>
+                <option value="&#9;">{t("csvProfiles.delimTab")}</option>
               </select>
             </label>
 
@@ -172,8 +172,8 @@ export function CsvProfileManager({ onClose }: Props) {
                 value={form.date_format}
                 onChange={(e) => setForm((f) => ({ ...f, date_format: e.target.value }))}
               >
-                <option value="iso">ISO (YYYY-MM-DD)</option>
-                <option value="dmy">DMY (DD.MM.YYYY)</option>
+                <option value="iso">{t("csvProfiles.dateFormatIso")}</option>
+                <option value="dmy">{t("csvProfiles.dateFormatDmy")}</option>
               </select>
             </label>
 

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -22,10 +22,10 @@ export function NavBar() {
     <nav className={styles.nav}>
       {/* Always-visible top bar (hamburger row) — desktop: hidden */}
       <div className={styles.bar}>
-        <span className={styles.brand}>My Finances</span>
+        <span className={styles.brand}>{t("nav.brand")}</span>
         <button
           className={styles.hamburger}
-          aria-label="Menu"
+          aria-label={t("nav.menu")}
           aria-expanded={open}
           onClick={() => setOpen((v) => !v)}
         >

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -12,7 +12,9 @@
     "rules": "Regeln",
     "import": "Importieren",
     "suggestions": "Vorschläge",
-    "settings": "Einstellungen"
+    "settings": "Einstellungen",
+    "brand": "Meine Finanzen",
+    "menu": "Menü"
   },
   "common": {
     "loading": "Lädt…",
@@ -104,7 +106,8 @@
     "currencyPlaceholder": "EUR",
     "creating": "Wird erstellt…",
     "create": "Erstellen",
-    "failedCreate": "Konto konnte nicht erstellt werden."
+    "failedCreate": "Konto konnte nicht erstellt werden.",
+    "openingAsOf": "{{amount}} zum {{date}}"
   },
   "trends": {
     "title": "Ausgabentrends",
@@ -300,7 +303,10 @@
     "colExternalId": "Referenz-Spalte",
     "save": "Speichern",
     "cancel": "Abbrechen",
-    "delete": "Löschen"
+    "delete": "Löschen",
+    "delimTab": "Tab",
+    "dateFormatIso": "ISO (JJJJ-MM-TT)",
+    "dateFormatDmy": "TMJ (TT.MM.JJJJ)"
   },
   "fileDropZone": {
     "placeholder": "CSV-Datei hier ablegen oder klicken zum Durchsuchen"

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -12,7 +12,9 @@
     "rules": "Rules",
     "import": "Import",
     "suggestions": "Suggestions",
-    "settings": "Settings"
+    "settings": "Settings",
+    "brand": "My Finances",
+    "menu": "Menu"
   },
   "common": {
     "loading": "Loading…",
@@ -104,7 +106,8 @@
     "currencyPlaceholder": "EUR",
     "creating": "Creating…",
     "create": "Create",
-    "failedCreate": "Failed to create account."
+    "failedCreate": "Failed to create account.",
+    "openingAsOf": "{{amount}} as of {{date}}"
   },
   "trends": {
     "title": "Spending Trends",
@@ -300,7 +303,10 @@
     "colExternalId": "Reference column",
     "save": "Save",
     "cancel": "Cancel",
-    "delete": "Delete"
+    "delete": "Delete",
+    "delimTab": "Tab",
+    "dateFormatIso": "ISO (YYYY-MM-DD)",
+    "dateFormatDmy": "DMY (DD.MM.YYYY)"
   },
   "fileDropZone": {
     "placeholder": "Drop a CSV file here or click to browse"

--- a/app/src/lib/api/client.ts
+++ b/app/src/lib/api/client.ts
@@ -9,52 +9,99 @@ export class ApiError extends Error {
   }
 }
 
-// Sent on every request. The backend's destructive endpoints require it (#99):
-// a cross-origin simple request can't set it without a CORS preflight, which
-// the origin allow-list blocks for unknown origins.
-const DEFAULT_HEADERS = {
-  Accept: "application/json",
-  "Content-Type": "application/json",
-  "X-Requested-With": "XMLHttpRequest",
+/** Thrown when a request exceeds its timeout (or its AbortSignal fires). */
+export class TimeoutError extends Error {
+  constructor(path: string) {
+    super(`Request timed out: ${path}`);
+    this.name = "TimeoutError";
+  }
+}
+
+/** Default per-request timeout. Override via `apiRequest(path, { timeoutMs })`. */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+type ApiInit = Omit<RequestInit, "signal"> & {
+  /** Extra signal to combine with the timeout (e.g. React Query's). */
+  signal?: AbortSignal;
+  /** Per-request timeout; `0` disables it. */
+  timeoutMs?: number;
 };
 
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(path, {
-    headers: DEFAULT_HEADERS,
-    ...init,
-  });
-  const body = await res.json().catch(() => null);
+function buildHeaders(init: ApiInit): Headers {
+  const headers = new Headers(init.headers);
+  // The backend's destructive endpoints require this (#99): a cross-origin
+  // simple request can't set a custom header without a CORS preflight, which
+  // the origin allow-list blocks for unknown origins.
+  headers.set("X-Requested-With", "XMLHttpRequest");
+  headers.set("Accept", "application/json");
+  // Only declare a JSON body — never on GET, and let the browser set the
+  // multipart boundary for FormData bodies.
+  if (typeof init.body === "string" && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  return headers;
+}
 
-  if (!res.ok) {
-    throw new ApiError(res.status, body);
+/**
+ * The single fetch primitive. Adds default headers, a timeout, and uniform
+ * `ApiError` / `TimeoutError` handling. Returns the parsed JSON body (or
+ * `undefined` for an empty 2xx response).
+ */
+export async function apiRequest<T>(path: string, init: ApiInit = {}): Promise<T> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: callerSignal, ...rest } = init;
+
+  const signals: AbortSignal[] = [];
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  if (timeoutMs > 0) {
+    const ac = new AbortController();
+    timer = setTimeout(() => ac.abort(), timeoutMs);
+    signals.push(ac.signal);
+  }
+  if (callerSignal) signals.push(callerSignal);
+  const signal = signals.length ? AbortSignal.any(signals) : undefined;
+
+  let res: Response;
+  try {
+    res = await fetch(path, { ...rest, headers: buildHeaders(init), signal });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new TimeoutError(path);
+    }
+    throw err;
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch {
+    body = null;
+  }
+
+  if (!res.ok) {
+    throw new ApiError(res.status, body ?? null);
+  }
   return body as T;
 }
 
-export async function apiGet<T>(path: string): Promise<T> {
-  return apiFetch<T>(path);
+export function apiGet<T>(path: string, init?: ApiInit): Promise<T> {
+  return apiRequest<T>(path, init);
 }
 
-export async function apiPost<T>(path: string, data: unknown): Promise<T> {
-  return apiFetch<T>(path, { method: "POST", body: JSON.stringify(data) });
+export function apiPost<T>(path: string, data: unknown, init?: ApiInit): Promise<T> {
+  return apiRequest<T>(path, { ...init, method: "POST", body: JSON.stringify(data) });
 }
 
-export async function apiPut<T>(path: string, data: unknown): Promise<T> {
-  return apiFetch<T>(path, { method: "PUT", body: JSON.stringify(data) });
+export function apiPut<T>(path: string, data: unknown, init?: ApiInit): Promise<T> {
+  return apiRequest<T>(path, { ...init, method: "PUT", body: JSON.stringify(data) });
 }
 
-export async function apiPatch<T>(path: string, data: unknown): Promise<T> {
-  return apiFetch<T>(path, { method: "PATCH", body: JSON.stringify(data) });
+export function apiPatch<T>(path: string, data: unknown, init?: ApiInit): Promise<T> {
+  return apiRequest<T>(path, { ...init, method: "PATCH", body: JSON.stringify(data) });
 }
 
-export async function apiDelete(path: string): Promise<void> {
-  const res = await fetch(path, {
-    method: "DELETE",
-    headers: { "X-Requested-With": "XMLHttpRequest" },
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new ApiError(res.status, body);
-  }
+export function apiDelete<T = void>(path: string, init?: ApiInit): Promise<T> {
+  return apiRequest<T>(path, { ...init, method: "DELETE" });
 }

--- a/app/src/lib/api/imports.ts
+++ b/app/src/lib/api/imports.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "./client";
+import { apiRequest } from "./client";
 
 export type ImportErrorDetail = {
   row?: number | null;
@@ -39,16 +39,10 @@ export async function importCsv(params: ImportCsvParams): Promise<ImportResult> 
   if (params.decimalComma !== undefined) query.set("decimal_comma", String(params.decimalComma));
   if (params.profileId !== undefined) query.set("profile_id", String(params.profileId));
 
-  const res = await fetch(`/api/imports/csv?${query}`, {
+  return apiRequest<ImportResult>(`/api/imports/csv?${query}`, {
     method: "POST",
     body: formData,
+    // Parsing + inserting a large CSV can take a while.
+    timeoutMs: 120_000,
   });
-
-  const body = await res.json().catch(() => null);
-
-  if (!res.ok) {
-    throw new ApiError(res.status, body);
-  }
-
-  return body as ImportResult;
 }

--- a/app/src/lib/api/settings.ts
+++ b/app/src/lib/api/settings.ts
@@ -1,40 +1,20 @@
-import { ApiError } from "./client";
+import { apiDelete, apiRequest } from "./client";
 
 export async function restoreSqlite(file: File): Promise<void> {
   const formData = new FormData();
   formData.append("file", file);
-
-  const res = await fetch("/api/restore/sqlite", {
+  await apiRequest<{ ok: boolean }>("/api/restore/sqlite", {
     method: "POST",
     body: formData,
-    headers: { "X-Requested-With": "XMLHttpRequest" },
+    // A restore recreates the DB file; give it room.
+    timeoutMs: 120_000,
   });
-  if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new ApiError(res.status, body);
-  }
 }
 
-export async function deleteTransactions(): Promise<{ deleted: number }> {
-  const res = await fetch("/api/data/transactions", {
-    method: "DELETE",
-    headers: { "X-Requested-With": "XMLHttpRequest" },
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new ApiError(res.status, body);
-  }
-  return res.json() as Promise<{ deleted: number }>;
+export function deleteTransactions(): Promise<{ deleted: number }> {
+  return apiDelete<{ deleted: number }>("/api/data/transactions");
 }
 
-export async function wipeAllData(): Promise<{ deleted: number }> {
-  const res = await fetch("/api/data", {
-    method: "DELETE",
-    headers: { "X-Requested-With": "XMLHttpRequest" },
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    throw new ApiError(res.status, body);
-  }
-  return res.json() as Promise<{ deleted: number }>;
+export function wipeAllData(): Promise<{ deleted: number }> {
+  return apiDelete<{ deleted: number }>("/api/data");
 }

--- a/app/src/pages/NetWorth.tsx
+++ b/app/src/pages/NetWorth.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useAccounts } from "../hooks/useAccounts";
@@ -71,8 +71,10 @@ function AccountRow({
           </div>
         ) : hasSetup ? (
           <span className={styles.openingInfo}>
-            {formatMoneyString(account.opening_balance!, currency)} as of{" "}
-            {account.opening_balance_date}
+            {t("netWorth.openingAsOf", {
+              amount: formatMoneyString(account.opening_balance!, currency),
+              date: account.opening_balance_date,
+            })}
             <button type="button" className={styles.editBtn} onClick={() => setEditing(true)}>
               {t("common.edit")}
             </button>

--- a/app/tests/lib/api-modules.test.ts
+++ b/app/tests/lib/api-modules.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getAccounts, createAccount, updateAccount } from "../../src/lib/api/accounts";
+import { getAnnualReport } from "../../src/lib/api/annual";
+import { getBudgets, createBudget, updateBudget, deleteBudget } from "../../src/lib/api/budgets";
+import { getCategories, deleteCategory } from "../../src/lib/api/categories";
+import { importCsv } from "../../src/lib/api/imports";
+import { getNetWorth } from "../../src/lib/api/netWorth";
+import { getRecurringPatterns, getRecurringSummary } from "../../src/lib/api/recurringPatterns";
+import { getMonthlyReport, getBudgetVsActual, getFixedVsVariable } from "../../src/lib/api/reports";
+import { deleteTransactions, wipeAllData } from "../../src/lib/api/settings";
+import { getSpendingTrend } from "../../src/lib/api/trends";
+import { getTransactions, updateTransactionCategory } from "../../src/lib/api/transactions";
+import { getTransferCandidates, confirmTransfer } from "../../src/lib/api/transfers";
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status });
+}
+
+function lastCall(): [string, RequestInit] {
+  const calls = vi.mocked(fetch).mock.calls;
+  return calls[calls.length - 1] as [string, RequestInit];
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve(jsonResponse({}))),
+  );
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("query-string builders", () => {
+  it("getMonthlyReport omits account_id for 'all'", async () => {
+    await getMonthlyReport({ accountId: "all", month: "2026-02" });
+    expect(lastCall()[0]).toBe("/api/reports/monthly?month=2026-02");
+
+    await getMonthlyReport({ accountId: 3, month: "2026-02" });
+    expect(lastCall()[0]).toBe("/api/reports/monthly?month=2026-02&account_id=3");
+  });
+
+  it("getBudgetVsActual / getFixedVsVariable build the right path", async () => {
+    await getBudgetVsActual({ accountId: 1, month: "2026-03" });
+    expect(lastCall()[0]).toContain("/api/reports/budget-vs-actual?month=2026-03");
+    await getFixedVsVariable({ accountId: "all", month: "2026-03" });
+    expect(lastCall()[0]).toBe("/api/reports/fixed-vs-variable?month=2026-03");
+  });
+
+  it("getTransactions only includes set params", async () => {
+    await getTransactions({ accountId: "all", limit: 25, q: "rewe" });
+    const url = lastCall()[0];
+    expect(url).toContain("limit=25");
+    expect(url).toContain("q=rewe");
+    expect(url).not.toContain("account_id");
+    expect(url).not.toContain("offset");
+  });
+
+  it("getSpendingTrend / getAnnualReport / getNetWorth", async () => {
+    await getSpendingTrend(6, 1, "2026-02");
+    expect(lastCall()[0]).toContain("/api/reports/spending-trend?");
+    expect(lastCall()[0]).toContain("lookback_months=6");
+    await getAnnualReport(2025, "all");
+    expect(lastCall()[0]).toBe("/api/reports/annual?year=2025");
+    await getNetWorth(24);
+    expect(lastCall()[0]).toBe("/api/reports/net-worth?months=24");
+  });
+
+  it("getRecurringPatterns / summary", async () => {
+    await getRecurringPatterns(2, true);
+    expect(lastCall()[0]).toContain("account_id=2");
+    expect(lastCall()[0]).toContain("include_inactive=true");
+    await getRecurringSummary(2);
+    expect(lastCall()[0]).toContain("/api/recurring-patterns/summary?");
+  });
+});
+
+describe("method + body", () => {
+  it("createAccount POSTs JSON", async () => {
+    await createAccount({ name: "Main", currency: "EUR" });
+    const [url, init] = lastCall();
+    expect(url).toBe("/api/accounts");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ name: "Main", currency: "EUR" }));
+  });
+
+  it("updateAccount PATCHes", async () => {
+    await updateAccount(5, { opening_balance: "100.00" });
+    expect(lastCall()[1].method).toBe("PATCH");
+    expect(lastCall()[0]).toBe("/api/accounts/5");
+  });
+
+  it("GET helpers", async () => {
+    await getAccounts();
+    expect(lastCall()[0]).toBe("/api/accounts");
+    await getCategories();
+    expect(lastCall()[0]).toBe("/api/categories");
+    await getBudgets();
+    expect(lastCall()[0]).toBe("/api/budgets");
+  });
+
+  it("budget mutations", async () => {
+    await createBudget({ category_id: 1, amount: "50" });
+    expect(lastCall()[1].method).toBe("POST");
+    await updateBudget(1, { amount: "60" });
+    expect(lastCall()[1].method).toBe("PATCH");
+    await deleteBudget(1);
+    expect(lastCall()[1].method).toBe("DELETE");
+    expect(lastCall()[0]).toBe("/api/budgets/1");
+  });
+
+  it("deleteCategory / updateTransactionCategory / transfers", async () => {
+    await deleteCategory(9);
+    expect(lastCall()[0]).toBe("/api/categories/9");
+    expect(lastCall()[1].method).toBe("DELETE");
+    await updateTransactionCategory(3, 7);
+    expect(lastCall()[1].body).toBe(JSON.stringify({ category_id: 7 }));
+    await getTransferCandidates("pending");
+    expect(lastCall()[0]).toContain("status=pending");
+    await confirmTransfer(4);
+    expect(lastCall()[0]).toBe("/api/transfers/candidates/4/confirm");
+  });
+
+  it("settings deletes hit the guarded endpoints", async () => {
+    vi.mocked(fetch).mockImplementation(() => Promise.resolve(jsonResponse({ deleted: 2 })));
+    await deleteTransactions();
+    expect(lastCall()[0]).toBe("/api/data/transactions");
+    expect((lastCall()[1].headers as Headers).get("X-Requested-With")).toBe("XMLHttpRequest");
+    await wipeAllData();
+    expect(lastCall()[0]).toBe("/api/data");
+  });
+
+  it("importCsv sends FormData without a JSON Content-Type", async () => {
+    vi.mocked(fetch).mockImplementation(() =>
+      Promise.resolve(jsonResponse({ total_rows: 0, created: 0 })),
+    );
+    const file = new File(["a,b\n1,2\n"], "x.csv", { type: "text/csv" });
+    await importCsv({ file, accountId: 1, delimiter: ";" });
+    const [url, init] = lastCall();
+    expect(url).toContain("/api/imports/csv?account_id=1");
+    expect(url).toContain("delimiter=%3B");
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.headers as Headers).has("Content-Type")).toBe(false);
+  });
+});

--- a/app/tests/pages/Budgets.test.tsx
+++ b/app/tests/pages/Budgets.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Budgets from "../../src/pages/Budgets";
+
+vi.mock("../../src/hooks/useBudgets", () => ({
+  useBudgets: () => ({
+    data: [{ id: 1, category_id: 5, category_name: "Groceries", amount: "300.00" }],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../../src/hooks/useCategories", () => ({
+  useCategories: () => ({
+    data: [
+      { id: 5, name: "Groceries", parent_id: null },
+      { id: 6, name: "Transport", parent_id: null },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Budgets />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Budgets page", () => {
+  it("renders the existing budget row", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: /budget/i })).toBeInTheDocument();
+    expect(screen.getByText("Groceries")).toBeInTheDocument();
+    expect(screen.getByText(/300/)).toBeInTheDocument();
+  });
+});

--- a/app/tests/pages/Suggestions.test.tsx
+++ b/app/tests/pages/Suggestions.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Suggestions from "../../src/pages/Suggestions";
+
+const train = { mutate: vi.fn(), isPending: false };
+
+vi.mock("../../src/hooks/useMl", () => ({
+  useSuggestions: () => ({
+    data: [
+      {
+        transaction_id: 1,
+        category_id: 3,
+        category_name: "Groceries",
+        confidence: 0.95,
+        payee: "REWE",
+        purpose: "Food",
+        amount: "-12.34",
+        booking_date: "2026-01-01",
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+  useTrainModel: () => train,
+  useAcceptSuggestion: () => ({ mutate: vi.fn() }),
+}));
+
+describe("Suggestions page", () => {
+  it("renders a high-confidence suggestion", () => {
+    render(
+      <MemoryRouter>
+        <Suggestions />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("heading", { name: /suggestion/i })).toBeInTheDocument();
+    expect(screen.getByText("REWE")).toBeInTheDocument();
+  });
+
+  it("retrains on button click", () => {
+    render(
+      <MemoryRouter>
+        <Suggestions />
+      </MemoryRouter>,
+    );
+    const btn = screen
+      .getAllByRole("button")
+      .find((b) => /train|retrain/i.test(b.textContent ?? ""));
+    btn?.click();
+    expect(train.mutate).toHaveBeenCalled();
+  });
+});

--- a/app/tests/pages/Transfers.test.tsx
+++ b/app/tests/pages/Transfers.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Transfers from "../../src/pages/Transfers";
+
+const detect = { mutate: vi.fn(), isPending: false, isSuccess: false, data: [] };
+
+vi.mock("../../src/hooks/useTransferCandidates", () => ({
+  useTransferCandidates: (status: string) => ({
+    data:
+      status === "pending"
+        ? [
+            {
+              id: 1,
+              from_leg: {
+                transaction_id: 10,
+                account_id: 1,
+                account_name: "Checking",
+                booking_date: "2026-01-01",
+                amount: "-100.00",
+                payee: "Savings",
+              },
+              to_leg: {
+                transaction_id: 11,
+                account_id: 2,
+                account_name: "Savings",
+                booking_date: "2026-01-01",
+                amount: "100.00",
+                payee: "Checking",
+              },
+              confidence: "0.9",
+              status: "pending",
+            },
+          ]
+        : [],
+    isLoading: false,
+    isError: false,
+  }),
+  useDetectTransfers: () => detect,
+  useConfirmTransfer: () => ({ mutate: vi.fn() }),
+  useDismissTransfer: () => ({ mutate: vi.fn() }),
+}));
+
+describe("Transfers page", () => {
+  it("renders the pending candidate and count badge", () => {
+    render(
+      <MemoryRouter>
+        <Transfers />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("heading", { name: /transfer/i })).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("triggers detection on button click", () => {
+    const { getByRole } = render(
+      <MemoryRouter>
+        <Transfers />
+      </MemoryRouter>,
+    );
+    getByRole("button", { name: /detect/i }).click();
+    expect(detect.mutate).toHaveBeenCalled();
+  });
+});

--- a/app/tests/utils/client.test.ts
+++ b/app/tests/utils/client.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiError, apiGet, apiPost } from "../../src/lib/api/client";
+import {
+  ApiError,
+  TimeoutError,
+  apiDelete,
+  apiGet,
+  apiPost,
+  apiRequest,
+} from "../../src/lib/api/client";
 
 describe("ApiError", () => {
   it("is an Error with status and body", () => {
@@ -78,5 +85,59 @@ describe("apiPost", () => {
     const [, init] = vi.mocked(fetch).mock.calls[0];
     expect((init as RequestInit).method).toBe("POST");
     expect((init as RequestInit).body).toBe(JSON.stringify({ name: "test" }));
+  });
+});
+
+describe("apiRequest headers, timeout, delete", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("never sends Content-Type on a bodyless GET, always sends X-Requested-With", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await apiGet("/api/x");
+    const headers = vi.mocked(fetch).mock.calls[0][1]!.headers as Headers;
+    expect(headers.has("Content-Type")).toBe(false);
+    expect(headers.get("X-Requested-With")).toBe("XMLHttpRequest");
+    expect(headers.get("Accept")).toBe("application/json");
+  });
+
+  it("sets Content-Type for a string body", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await apiPost("/api/x", { a: 1 });
+    const headers = vi.mocked(fetch).mock.calls[0][1]!.headers as Headers;
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("leaves Content-Type unset for a FormData body", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    const fd = new FormData();
+    fd.append("f", "v");
+    await apiRequest("/api/upload", { method: "POST", body: fd });
+    const headers = vi.mocked(fetch).mock.calls[0][1]!.headers as Headers;
+    expect(headers.has("Content-Type")).toBe(false);
+  });
+
+  it("apiDelete issues a DELETE and resolves undefined on empty body", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("", { status: 200 }));
+    const out = await apiDelete("/api/thing/1");
+    expect(out).toBeUndefined();
+    expect(vi.mocked(fetch).mock.calls[0][1]!.method).toBe("DELETE");
+  });
+
+  it("throws TimeoutError when the request aborts", async () => {
+    vi.mocked(fetch).mockImplementationOnce((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = (init as RequestInit).signal!;
+        signal.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    });
+    await expect(apiGet("/api/slow", { timeoutMs: 5 })).rejects.toBeInstanceOf(TimeoutError);
   });
 });

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -9,5 +9,19 @@ export default defineConfig({
     setupFiles: ["./tests/setup.ts"],
     // Unit/component tests only. Playwright specs in e2e/ are run by `make e2e`.
     include: ["tests/**/*.{test,spec}.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/main.tsx", "src/**/*.d.ts", "src/vite-env.d.ts", "src/i18n/**"],
+      reporter: ["text-summary", "html"],
+      // Starting floor — a ratchet, like the backend's MIN_COVERAGE. Raise these
+      // as coverage grows; never lower them.
+      thresholds: {
+        lines: 30,
+        functions: 20,
+        branches: 24,
+        statements: 30,
+      },
+    },
   },
 });


### PR DESCRIPTION
Closes #113 and #116 (both finding C14). Frontend only, off `main`.

## #113 — client / timeouts / i18n

- **`lib/api/client.ts`** — one `apiRequest` primitive:
  - `Accept` + `X-Requested-With` on every request; `Content-Type:
    application/json` **only** for a string body (never GET, never FormData —
    the browser sets the multipart boundary)
  - per-request **`timeoutMs`** (default 30s) via `AbortController` +
    `AbortSignal.any`; composes with a caller signal (React Query); abort →
    `TimeoutError`
  - `apiGet/apiPost/apiPut/apiPatch/apiDelete` all delegate; `apiDelete<T>`
    can return a body
- **`lib/api/imports.ts`** + **`lib/api/settings.ts`** drop their hand-rolled
  `fetch` + `ApiError` and use `apiRequest` (FormData, 120s timeout for
  import / restore)
- **i18n leaks** routed through `t()`: `NetWorth` `" as of "`, `NavBar` brand +
  menu `aria-label`, `CsvProfileManager` Tab / date-format `<option>` labels
  (keys added to `en` + `de`)
- dropped the unnecessary `import React` in `NetWorth.tsx`

## #116 — coverage floor + tests

- `@vitest/coverage-v8` + a `coverage` block in `vitest.config.ts` with a
  **threshold floor** (lines 30 / statements 30 / branches 24 / functions 20)
  — a ratchet like the backend's `MIN_COVERAGE`. Raise as coverage grows.
- `pnpm test:coverage`; `make -C app ci` runs it (so CI enforces the floor)
- new tests: `tests/lib/api-modules.test.ts` (URL/body across ~14 api
  modules), `tests/utils/client.test.ts` extended (headers / timeout / delete /
  FormData), `tests/pages/{Transfers,Budgets,Suggestions}.test.tsx`
- **coverage 20% → 33% lines**; 68 tests (was 46)

## Verification

Run with Node 24 (CI's `.nvmrc`): `lint` (0 errors), `typecheck`,
`format:check`, `test:coverage` (thresholds met) all green.

Remaining #116 work (more page/component RTL tests, ratcheting the floor up)
is follow-up.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm