### PR TITLE
feat(api): explicit ON DELETE semantics for all foreign keys (#117)

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -35,6 +35,9 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         compare_type=True,
+        # SQLite can't ALTER most constraints in place — autogenerate every
+        # migration as a table-recreate batch (see #117).
+        render_as_batch=True,
         dialect_opts={"paramstyle": "named"},
     )
 
@@ -47,6 +50,7 @@ def do_run_migrations(connection: Connection) -> None:
         connection=connection,
         target_metadata=target_metadata,
         compare_type=True,
+        render_as_batch=True,
     )
 
     with context.begin_transaction():

--- a/api/alembic/versions/e8c8c7121cfd_add_ondelete_semantics_to_foreign_keys.py
+++ b/api/alembic/versions/e8c8c7121cfd_add_ondelete_semantics_to_foreign_keys.py
@@ -1,0 +1,79 @@
+"""add ondelete semantics to foreign keys
+
+Revision ID: e8c8c7121cfd
+Revises: 73cfdb5307bb
+Create Date: 2026-09-08 21:29:02.073516
+
+Follow-up to #96 (PRAGMA foreign_keys=ON). All FKs were created without an
+``ON DELETE`` clause (i.e. RESTRICT). This gives each one an explicit policy:
+
+* RESTRICT — deleting the parent is blocked while children exist
+* SET NULL — the child's FK column is nulled (only nullable columns)
+* CASCADE  — the child row is deleted with the parent
+
+SQLite can't ``ALTER`` a constraint, so every table is recreated via batch
+mode. A naming convention lets the pre-existing unnamed FKs be addressed by
+``drop_constraint``.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e8c8c7121cfd"
+down_revision: Union[str, Sequence[str], None] = "73cfdb5307bb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_NAMING = {
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+}
+
+# table -> [(column, referred_table, ondelete policy)]
+_FKS: dict[str, list[tuple[str, str, str]]] = {
+    "budget": [("category_id", "category", "CASCADE")],
+    "categorization_rule": [("category_id", "category", "CASCADE")],
+    "category": [("parent_id", "category", "SET NULL")],
+    "recurring_pattern": [
+        ("account_id", "account", "CASCADE"),
+        ("category_id", "category", "SET NULL"),
+    ],
+    "transaction": [
+        ("account_id", "account", "RESTRICT"),
+        ("category_id", "category", "SET NULL"),
+    ],
+    "transfer_candidate": [
+        ("from_transaction_id", "transaction", "CASCADE"),
+        ("to_transaction_id", "transaction", "CASCADE"),
+    ],
+    "watch_folder_config": [
+        ("account_id", "account", "CASCADE"),
+        ("profile_id", "csv_profile", "SET NULL"),
+    ],
+}
+
+
+def _rebuild(*, with_ondelete: bool) -> None:
+    for table, fks in _FKS.items():
+        with op.batch_alter_table(table, naming_convention=_NAMING) as batch_op:
+            for column, referred, _policy in fks:
+                batch_op.drop_constraint(
+                    f"fk_{table}_{column}_{referred}", type_="foreignkey"
+                )
+            for column, referred, policy in fks:
+                batch_op.create_foreign_key(
+                    f"fk_{table}_{column}_{referred}",
+                    referred,
+                    [column],
+                    ["id"],
+                    ondelete=policy if with_ondelete else None,
+                )
+
+
+def upgrade() -> None:
+    _rebuild(with_ondelete=True)
+
+
+def downgrade() -> None:
+    _rebuild(with_ondelete=False)

--- a/api/my_private_finances/api/routes/categories.py
+++ b/api/my_private_finances/api/routes/categories.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Body, HTTPException
-from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
 from my_private_finances.deps import SessionDep
@@ -77,6 +76,10 @@ async def delete_category(category_id: int, session: SessionDep) -> None:
         raise HTTPException(status_code=404, detail="Category not found")
 
     # Check if any transactions reference this category
+    # Transactions are the one relationship we refuse to touch implicitly — the
+    # user must re-categorise or accept losing the categorisation first. Every
+    # other reference is handled by the FK's ON DELETE (#117): budgets and rules
+    # CASCADE, sub-categories and recurring patterns SET NULL.
     result = await session.execute(
         select(Transaction.id).where(Transaction.category_id == category_id).limit(1)
     )
@@ -87,17 +90,4 @@ async def delete_category(category_id: int, session: SessionDep) -> None:
         )
 
     await session.delete(db_obj)
-    try:
-        await session.commit()
-    except IntegrityError as e:
-        # Foreign keys are enforced (PRAGMA foreign_keys=ON): the category is
-        # still referenced by a budget, categorization rule, sub-category, or
-        # recurring pattern.
-        await session.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                "Category is still referenced (budget, rule, sub-category, or "
-                "recurring pattern) and cannot be deleted"
-            ),
-        ) from e
+    await session.commit()

--- a/api/my_private_finances/api/routes/csv_profiles.py
+++ b/api/my_private_finances/api/routes/csv_profiles.py
@@ -102,13 +102,8 @@ async def delete_csv_profile(profile_id: int, session: SessionDep) -> None:
     db_obj = await session.get(CsvProfile, profile_id)
     if db_obj is None:
         raise HTTPException(status_code=404, detail="Profile not found")
+    # watch_folder_config.profile_id is ON DELETE SET NULL (#117): any config
+    # using this profile falls back to the built-in CSV defaults.
     await session.delete(db_obj)
-    try:
-        await session.commit()
-    except IntegrityError as e:
-        await session.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail="Profile is in use by a watch-folder config and cannot be deleted",
-        ) from e
+    await session.commit()
     logger.info("CSV profile deleted: id=%d", profile_id)

--- a/api/my_private_finances/api/routes/data_management.py
+++ b/api/my_private_finances/api/routes/data_management.py
@@ -142,10 +142,16 @@ async def _count(session: SessionDep, model: type) -> int:
 )
 async def delete_transactions(session: SessionDep) -> dict:
     """Delete all transactions, transfer candidates, and recurring patterns."""
-    models = [TransferCandidate, RecurringPattern, Transaction]
-    deleted = sum([await _count(session, m) for m in models])
-    for model in models:
-        await session.execute(delete(model))
+    deleted = sum(
+        [
+            await _count(session, m)
+            for m in (TransferCandidate, RecurringPattern, Transaction)
+        ]
+    )
+    # transfer_candidate.*_transaction_id is ON DELETE CASCADE (#117), so
+    # deleting the transactions clears the candidates too.
+    await session.execute(delete(RecurringPattern))
+    await session.execute(delete(Transaction))
     await session.commit()
     logger.info("Deleted all transactions: %d rows total", deleted)
     return {"deleted": deleted}

--- a/api/my_private_finances/models/budget.py
+++ b/api/my_private_finances/models/budget.py
@@ -10,7 +10,7 @@ from my_private_finances.models.mixins import TimestampMixin
 
 
 class BudgetBase(SQLModel):
-    category_id: int = Field(foreign_key="category.id")
+    category_id: int = Field(foreign_key="category.id", ondelete="CASCADE")
     amount: Decimal = Field(sa_column=Column(Numeric(12, 2), nullable=False))
 
 

--- a/api/my_private_finances/models/categorization_rule.py
+++ b/api/my_private_finances/models/categorization_rule.py
@@ -18,4 +18,4 @@ class CategorizationRule(TimestampMixin, table=True):
     field: str = Field(sa_column=Column(String(20), nullable=False))
     operator: str = Field(sa_column=Column(String(20), nullable=False))
     value: str = Field(sa_column=Column(String(255), nullable=False))
-    category_id: int = Field(foreign_key="category.id")
+    category_id: int = Field(foreign_key="category.id", ondelete="CASCADE")

--- a/api/my_private_finances/models/category.py
+++ b/api/my_private_finances/models/category.py
@@ -10,7 +10,9 @@ from my_private_finances.models.mixins import TimestampMixin
 
 class CategoryBase(SQLModel):
     name: str = Field(sa_column=Column(String(120), nullable=False, index=True))
-    parent_id: Optional[int] = Field(default=None, foreign_key="category.id")
+    parent_id: Optional[int] = Field(
+        default=None, foreign_key="category.id", ondelete="SET NULL"
+    )
     cost_type: Optional[str] = Field(
         default=None, sa_column=Column(String(10), nullable=True)
     )

--- a/api/my_private_finances/models/recurring_pattern.py
+++ b/api/my_private_finances/models/recurring_pattern.py
@@ -11,7 +11,7 @@ from my_private_finances.models.mixins import TimestampMixin
 
 
 class RecurringPatternBase(SQLModel):
-    account_id: int = Field(foreign_key="account.id", index=True)
+    account_id: int = Field(foreign_key="account.id", ondelete="CASCADE", index=True)
     payee: str = Field(sa_column=Column(String(255), nullable=False))
     typical_amount: Decimal = Field(sa_column=Column(Numeric(14, 2), nullable=False))
     frequency: str = Field(sa_column=Column(String(20), nullable=False))
@@ -20,7 +20,9 @@ class RecurringPatternBase(SQLModel):
     occurrence_count: int = Field(default=0)
     is_active: bool = Field(default=True)
     user_confirmed: bool = Field(default=False)
-    category_id: Optional[int] = Field(default=None, foreign_key="category.id")
+    category_id: Optional[int] = Field(
+        default=None, foreign_key="category.id", ondelete="SET NULL"
+    )
 
 
 class RecurringPattern(TimestampMixin, RecurringPatternBase, table=True):

--- a/api/my_private_finances/models/transaction.py
+++ b/api/my_private_finances/models/transaction.py
@@ -11,7 +11,7 @@ from my_private_finances.models.mixins import TimestampMixin
 
 
 class TransactionBase(SQLModel):
-    account_id: int = Field(foreign_key="account.id", index=True)
+    account_id: int = Field(foreign_key="account.id", ondelete="RESTRICT", index=True)
 
     booking_date: date = Field(sa_column=Column(Date, nullable=False, index=True))
 
@@ -22,7 +22,9 @@ class TransactionBase(SQLModel):
     purpose: Optional[str] = Field(default=None, sa_column=Column(Text))
     notes: Optional[str] = Field(default=None, sa_column=Column(Text))
 
-    category_id: Optional[int] = Field(default=None, foreign_key="category.id")
+    category_id: Optional[int] = Field(
+        default=None, foreign_key="category.id", ondelete="SET NULL"
+    )
 
     external_id: Optional[str] = Field(default=None, sa_column=Column(String(128)))
     import_source: Optional[str] = Field(default=None, sa_column=Column(String(64)))

--- a/api/my_private_finances/models/transfer_candidate.py
+++ b/api/my_private_finances/models/transfer_candidate.py
@@ -13,9 +13,13 @@ class TransferCandidate(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
 
     # Negative leg (outgoing transaction, e.g. -500 in Account 1)
-    from_transaction_id: int = Field(foreign_key="transaction.id", index=True)
+    from_transaction_id: int = Field(
+        foreign_key="transaction.id", ondelete="CASCADE", index=True
+    )
     # Positive leg (incoming transaction, e.g. +500 in Account 2)
-    to_transaction_id: int = Field(foreign_key="transaction.id", index=True)
+    to_transaction_id: int = Field(
+        foreign_key="transaction.id", ondelete="CASCADE", index=True
+    )
 
     confidence: Decimal = Field(sa_column=Column(Numeric(3, 2), nullable=False))
 

--- a/api/my_private_finances/models/watch_folder_config.py
+++ b/api/my_private_finances/models/watch_folder_config.py
@@ -17,5 +17,7 @@ class WatchFolderConfig(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     subfolder_name: str = Field(unique=True)
-    account_id: int = Field(foreign_key="account.id")
-    profile_id: Optional[int] = Field(default=None, foreign_key="csv_profile.id")
+    account_id: int = Field(foreign_key="account.id", ondelete="CASCADE")
+    profile_id: Optional[int] = Field(
+        default=None, foreign_key="csv_profile.id", ondelete="SET NULL"
+    )

--- a/api/tests/test_foreign_keys.py
+++ b/api/tests/test_foreign_keys.py
@@ -42,21 +42,51 @@ async def test_create_transaction_with_unknown_category_returns_422(
 
 
 @pytest.mark.asyncio
-async def test_delete_category_referenced_by_budget_returns_409(
-    test_app: AsyncClient,
-) -> None:
+async def test_delete_category_cascades_its_budget(test_app: AsyncClient) -> None:
+    """category -> budget FK is ON DELETE CASCADE (#117)."""
     cat = await create_category(test_app, name="Rent")
     await create_budget(test_app, category_id=cat["id"], amount="900.00")
 
     res = await test_app.delete(f"/api/categories/{cat['id']}")
-    assert res.status_code == 409
+    assert res.status_code == 204
 
-    # The category and its budget are both still there.
-    assert len((await test_app.get("/api/categories")).json()) == 1
+    assert (await test_app.get("/api/categories")).json() == []
+    assert (
+        await test_app.get("/api/reports/budget-vs-actual", params={"month": "2026-01"})
+    ).json() == []
 
 
 @pytest.mark.asyncio
-async def test_delete_csv_profile_in_use_returns_409(test_app: AsyncClient) -> None:
+async def test_delete_category_in_use_by_transactions_still_409(
+    test_app: AsyncClient,
+) -> None:
+    """Transactions are the one reference the route refuses to touch implicitly."""
+    account = await create_account(test_app)
+    cat = await create_category(test_app, name="Food")
+    tx = await test_app.post(
+        "/api/transactions",
+        json={
+            "account_id": account["id"],
+            "booking_date": "2026-02-01",
+            "amount": "-5.00",
+            "currency": "EUR",
+            "payee": "REWE",
+            "purpose": "x",
+            "import_source": "manual",
+            "external_id": "fk-cat-1",
+            "category_id": cat["id"],
+        },
+    )
+    assert tx.status_code == 201, tx.text
+    res = await test_app.delete(f"/api/categories/{cat['id']}")
+    assert res.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_delete_csv_profile_in_use_nulls_the_config(
+    test_app: AsyncClient,
+) -> None:
+    """watch_folder_config.profile_id is ON DELETE SET NULL (#117)."""
     account = await create_account(test_app)
     profile = (await test_app.post("/api/csv-profiles", json={"name": "Bank X"})).json()
     cfg = await test_app.post(
@@ -70,4 +100,7 @@ async def test_delete_csv_profile_in_use_returns_409(test_app: AsyncClient) -> N
     assert cfg.status_code == 201, cfg.text
 
     res = await test_app.delete(f"/api/csv-profiles/{profile['id']}")
-    assert res.status_code == 409
+    assert res.status_code == 204
+
+    configs = (await test_app.get("/api/watch-folder/configs")).json()
+    assert configs[0]["profile_id"] is None


### PR DESCRIPTION
Closes #117. Follow-up to #96 — every FK was left at the implicit RESTRICT.

## Per-FK policy

| FK | ON DELETE |
|---|---|
| `transaction.account_id` | **RESTRICT** |
| `transaction.category_id` | SET NULL |
| `category.parent_id` | SET NULL |
| `recurring_pattern.category_id` | SET NULL |
| `watch_folder_config.profile_id` | SET NULL |
| `budget.category_id` | CASCADE |
| `categorization_rule.category_id` | CASCADE |
| `recurring_pattern.account_id` | CASCADE |
| `transfer_candidate.{from,to}_transaction_id` | CASCADE |
| `watch_folder_config.account_id` | CASCADE |

Set via SQLModel `Field(foreign_key=..., ondelete=...)`.

## Migration

- `alembic/env.py` — `render_as_batch=True` on both `context.configure` calls.
- `e8c8c7121cfd` (`down_revision = 73cfdb5307bb`) — recreates the 7 affected
  tables in SQLite batch mode; a naming convention lets the pre-existing unnamed
  FKs be dropped and re-created with the clause. `upgrade` + `downgrade` + the
  cascade / set-null / restrict behaviour all verified on a seeded DB.

## Endpoint cleanup (issue checkbox: "simplify where CASCADE handles cleanup")

- `delete_category` — removed the now-dead `IntegrityError` branch (budget/rule
  CASCADE, sub-category/recurring SET NULL). **Kept** the explicit 409 when
  transactions reference the category — that's the one link the route won't
  sever implicitly.
- `delete_csv_profile` — removed the `IntegrityError` branch; watch config falls
  back to CSV defaults via SET NULL.
- `delete_transactions` — dropped the explicit `TransferCandidate` delete
  (cascades from `Transaction`).

`test_foreign_keys.py` updated: the two "returns 409" tests now assert
CASCADE / SET NULL; added a test that a category still in use by transactions
stays 409.

## Verification

- `ruff` + `mypy` clean
- `pytest` all pass; coverage 84%
- `alembic check` — no drift

**This is the last Post-review hardening issue** — merging it takes the
milestone to 21/21 (with #112 the only remaining, non-blocking, item... actually
#112 is also a milestone issue — 20/21, #112 left).

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm