### PR TITLE
test(app): RTL tests for remaining untested pages + components (#116)

### DIFF
--- a/app/tests/components/components-smoke.test.tsx
+++ b/app/tests/components/components-smoke.test.tsx
@@ -1,0 +1,90 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+
+import { renderApp } from "../render";
+
+// jsdom doesn't implement <dialog>.
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal ??= function () {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close ??= function () {
+    this.open = false;
+  };
+});
+
+vi.mock("../../src/hooks/useAccounts", () => ({
+  useAccounts: () => ({
+    data: [{ id: 1, name: "Main", currency: "EUR" }],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../../src/hooks/useCsvProfiles", () => ({
+  useCsvProfiles: () => ({
+    profiles: {
+      data: [
+        {
+          id: 1,
+          name: "DKB Giro",
+          delimiter: ";",
+          date_format: "dmy",
+          decimal_comma: true,
+          column_map: {},
+        },
+      ],
+    },
+    create: { mutate: vi.fn(), isPending: false },
+    update: { mutate: vi.fn(), isPending: false },
+    remove: { mutate: vi.fn() },
+  }),
+}));
+
+vi.mock("../../src/hooks/useImportCsv", () => ({
+  useImportCsv: () => ({ mutate: vi.fn(), isPending: false, reset: vi.fn() }),
+}));
+
+const emptyQuery = { data: [], isLoading: false, isError: false };
+vi.mock("../../src/hooks/useWatchFolder", () => ({
+  useWatchSettings: () => ({ data: { root_path: "data/watch" } }),
+  useUpdateWatchSettings: () => ({ mutate: vi.fn(), isPending: false }),
+  useWatchConfigs: () => emptyQuery,
+  useCreateWatchConfig: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateWatchConfig: () => ({ mutate: vi.fn() }),
+  useDeleteWatchConfig: () => ({ mutate: vi.fn() }),
+}));
+
+import { CategorySelect } from "../../src/components/CategorySelect";
+import { CsvProfileManager } from "../../src/components/CsvProfileManager";
+import { ImportDialog } from "../../src/components/ImportDialog";
+import { WatchFolderPanel } from "../../src/components/WatchFolderPanel";
+
+const CATS = [
+  { id: 1, name: "Groceries", parent_id: null, cost_type: null },
+  { id: 2, name: "Rent", parent_id: null, cost_type: null },
+];
+
+describe("component smoke tests", () => {
+  it("CategorySelect opens its list on click", () => {
+    renderApp(<CategorySelect categories={CATS} value={null} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("Groceries")).toBeInTheDocument();
+    expect(screen.getByText("Rent")).toBeInTheDocument();
+  });
+
+  it("CsvProfileManager lists existing profiles", () => {
+    renderApp(<CsvProfileManager onClose={vi.fn()} />);
+    expect(screen.getByText("DKB Giro")).toBeInTheDocument();
+  });
+
+  it("ImportDialog renders when open", () => {
+    renderApp(<ImportDialog open onClose={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: /import/i })).toBeInTheDocument();
+  });
+
+  it("WatchFolderPanel renders its subfolder section", () => {
+    renderApp(<WatchFolderPanel />);
+    expect(screen.getByText("Subfolder mappings")).toBeInTheDocument();
+  });
+});

--- a/app/tests/pages/pages-smoke.test.tsx
+++ b/app/tests/pages/pages-smoke.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderApp } from "../render";
+
+vi.mock("../../src/hooks/useAccounts", () => ({
+  useAccounts: () => ({
+    data: [{ id: 1, name: "Main", currency: "EUR" }],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../../src/hooks/useRecurringPatterns", () => ({
+  useRecurringPatterns: () => ({ data: [], isLoading: false, isError: false }),
+  useRecurringSummary: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock("../../src/hooks/useTrends", () => ({
+  useSpendingTrend: () => ({ data: undefined, isLoading: false, isError: false }),
+}));
+
+vi.mock("../../src/hooks/useAnnual", () => ({
+  useAnnualReport: () => ({ data: undefined, isLoading: false, isError: false }),
+}));
+
+vi.mock("../../src/hooks/useCategories", () => ({
+  useCategories: () => ({
+    data: [
+      { id: 1, name: "Groceries", parent_id: null, cost_type: "variable" },
+      { id: 2, name: "Rent", parent_id: null, cost_type: "fixed" },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+import AnnualOverview from "../../src/pages/AnnualOverview";
+import Categories from "../../src/pages/Categories";
+import Recurring from "../../src/pages/Recurring";
+import SpendingTrends from "../../src/pages/SpendingTrends";
+
+describe("page smoke tests", () => {
+  it("Recurring renders its title", () => {
+    renderApp(<Recurring />);
+    expect(screen.getByRole("heading", { name: /recurring/i })).toBeInTheDocument();
+  });
+
+  it("SpendingTrends renders its title", () => {
+    renderApp(<SpendingTrends />);
+    expect(screen.getByRole("heading", { name: /spending trend/i })).toBeInTheDocument();
+  });
+
+  it("AnnualOverview renders its title", () => {
+    renderApp(<AnnualOverview />);
+    expect(screen.getByRole("heading", { name: /annual/i })).toBeInTheDocument();
+  });
+
+  it("Categories renders its categories", () => {
+    renderApp(<Categories />);
+    expect(screen.getByRole("heading", { name: /categories/i })).toBeInTheDocument();
+    expect(screen.getByText("Groceries")).toBeInTheDocument();
+    expect(screen.getByText("Rent")).toBeInTheDocument();
+  });
+});

--- a/app/tests/render.tsx
+++ b/app/tests/render.tsx
@@ -1,0 +1,16 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+/** Render a component with the providers every page/component expects. */
+export function renderApp(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -17,10 +17,10 @@ export default defineConfig({
       // Starting floor — a ratchet, like the backend's MIN_COVERAGE. Raise these
       // as coverage grows; never lower them.
       thresholds: {
-        lines: 30,
-        functions: 20,
-        branches: 24,
-        statements: 30,
+        lines: 38,
+        functions: 24,
+        branches: 32,
+        statements: 38,
       },
     },
   },


### PR DESCRIPTION
Closes #116. Follow-up to #145 (which shipped the coverage ratchet + Transfers /
Budgets / Suggestions tests).

Adds the rest of the pages/components the issue lists:

- **`tests/render.tsx`** — shared `renderApp` (QueryClient + MemoryRouter).
- **`tests/pages/pages-smoke.test.tsx`** — Recurring, SpendingTrends,
  AnnualOverview, Categories.
- **`tests/components/components-smoke.test.tsx`** — CategorySelect,
  CsvProfileManager, ImportDialog, WatchFolderPanel (+ a jsdom
  `HTMLDialogElement.showModal` polyfill).

**Coverage floor raised** `30/20/24/30` → `38/24/32/38`
(lines / functions / branches / statements). Actual: **~42% lines, 76 tests**
(was 33% / 68).

Node 24: `lint` (0 errors) / `typecheck` / `format:check` / `test:coverage` green.

https://claude.ai/code/session_01UbvWhDy7JnZ8SenUP6Utnm